### PR TITLE
refactor(api): standardize controllers and security stats

### DIFF
--- a/hekponweu-rucho/pi-staking
+++ b/hekponweu-rucho/pi-staking
@@ -1,0 +1,1 @@
+/project/workspace/pi-staking

--- a/pi-staking/apps/backend/app/Http/Controllers/AdminController.php
+++ b/pi-staking/apps/backend/app/Http/Controllers/AdminController.php
@@ -26,89 +26,74 @@ class AdminController extends Controller
     public function getDashboardStats(): JsonResponse
     {
         try {
-            // Métriques générales
             $totalUsers = User::count();
             $activeUsers = User::where('last_activity', '>=', now()->subDays(30))->count();
             $newUsersToday = User::whereDate('created_at', today())->count();
             $newUsersThisWeek = User::whereBetween('created_at', [now()->startOfWeek(), now()->endOfWeek()])->count();
 
-            // Métriques financières
             $totalInvested = Investment::where('status', 'active')->sum('amount');
             $totalClaimed = Claim::where('status', 'completed')->sum('final_amount');
             $pendingClaims = Investment::where('status', 'active')
                 ->where('next_claim_available_at', '<=', now())
                 ->count();
             
-            // Calcul du TVL (Total Value Locked)
             $tvl = Investment::where('status', 'active')->sum('amount');
             $dailyVolume = Investment::whereDate('created_at', today())->sum('amount');
             
-            // Revenus de la plateforme (frais)
             $platformRevenue = $this->calculatePlatformRevenue();
-            
-            // Ratios de santé financière
             $liquidityRatio = $this->calculateLiquidityRatio();
             $claimRatio = $totalClaimed > 0 ? ($totalInvested / $totalClaimed) : 0;
 
-            // Alertes système
             $activeAlerts = SystemAlert::where('is_resolved', false)
                 ->where('severity', '!=', 'low')
                 ->count();
 
-            // Packages les plus populaires
             $popularPackages = StakingPackage::withCount('investments')
                 ->orderBy('investments_count', 'desc')
                 ->take(3)
                 ->get();
 
-            return response()->json([
-                'success' => true,
-                'data' => [
-                    'overview' => [
-                        'total_users' => $totalUsers,
-                        'active_users' => $activeUsers,
-                        'new_users_today' => $newUsersToday,
-                        'new_users_week' => $newUsersThisWeek,
-                        'active_users_percentage' => $totalUsers > 0 ? round(($activeUsers / $totalUsers) * 100, 1) : 0,
-                        'user_growth_rate' => $this->calculateUserGrowthRate(),
-                    ],
-                    'financial' => [
-                        'total_value_locked' => $tvl,
-                        'total_invested' => $totalInvested,
-                        'total_claimed' => $totalClaimed,
-                        'daily_volume' => $dailyVolume,
-                        'platform_revenue' => $platformRevenue,
-                        'pending_claims' => $pendingClaims,
-                        'pending_claims_amount' => $this->calculatePendingClaimsAmount(),
-                        'liquidity_ratio' => $liquidityRatio,
-                        'claim_ratio' => round($claimRatio, 2),
-                    ],
-                    'health_indicators' => [
-                        'liquidity_status' => $this->getLiquidityStatus($liquidityRatio),
-                        'platform_status' => $this->getPlatformStatus(),
-                        'active_alerts' => $activeAlerts,
-                        'system_load' => $this->getSystemLoad(),
-                    ],
-                    'popular_packages' => $popularPackages->map(function ($package) {
-                        return [
-                            'id' => $package->id,
-                            'name' => $package->name,
-                            'investments_count' => $package->investments_count,
-                            'daily_rate' => $package->daily_rate * 100,
-                            'total_invested' => Investment::where('package_id', $package->id)
-                                ->where('status', 'active')
-                                ->sum('amount'),
-                        ];
-                    }),
-                ]
-            ]);
+            return $this->success([
+                'overview' => [
+                    'total_users' => $totalUsers,
+                    'active_users' => $activeUsers,
+                    'new_users_today' => $newUsersToday,
+                    'new_users_week' => $newUsersThisWeek,
+                    'active_users_percentage' => $totalUsers > 0 ? round(($activeUsers / $totalUsers) * 100, 1) : 0,
+                    'user_growth_rate' => $this->calculateUserGrowthRate(),
+                ],
+                'financial' => [
+                    'total_value_locked' => $tvl,
+                    'total_invested' => $totalInvested,
+                    'total_claimed' => $totalClaimed,
+                    'daily_volume' => $dailyVolume,
+                    'platform_revenue' => $platformRevenue,
+                    'pending_claims' => $pendingClaims,
+                    'pending_claims_amount' => $this->calculatePendingClaimsAmount(),
+                    'liquidity_ratio' => $liquidityRatio,
+                    'claim_ratio' => round($claimRatio, 2),
+                ],
+                'health_indicators' => [
+                    'liquidity_status' => $this->getLiquidityStatus($liquidityRatio),
+                    'platform_status' => $this->getPlatformStatus(),
+                    'active_alerts' => $activeAlerts,
+                    'system_load' => $this->getSystemLoad(),
+                ],
+                'popular_packages' => $popularPackages->map(function ($package) {
+                    return [
+                        'id' => $package->id,
+                        'name' => $package->name,
+                        'investments_count' => $package->investments_count,
+                        'daily_rate' => $package->daily_rate * 100,
+                        'total_invested' => Investment::where('package_id', $package->id)
+                            ->where('status', 'active')
+                            ->sum('amount'),
+                    ];
+                }),
+            ], 'Stats admin');
 
-        } catch (\Exception $e) {
-            return response()->json([
-                'success' => false,
-                'message' => 'Erreur lors de la récupération des statistiques admin',
-                'error' => config('app.debug') ? $e->getMessage() : null
-            ], 500);
+        } catch (\Throwable $e) {
+            return $this->exception($e, 'Erreur lors de la récupération des statistiques admin');
         }
     }
 

--- a/pi-staking/apps/backend/app/Http/Controllers/Concerns/ApiResponses.php
+++ b/pi-staking/apps/backend/app/Http/Controllers/Concerns/ApiResponses.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Http\Controllers\Concerns;
+
+use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use Illuminate\Http\JsonResponse;
+
+trait ApiResponses
+{
+    protected function success(array|object|null $data = null, string $message = 'OK', int $status = 200, array $meta = []): JsonResponse
+    {
+        $payload = [
+            'success' => true,
+            'message' => $message,
+        ];
+        if ($data !== null) {
+            $payload['data'] = $data;
+        }
+        if (!empty($meta)) {
+            $payload['meta'] = $meta;
+        }
+        return response()->json($payload, $status);
+    }
+
+    protected function fail(string $message = 'Erreur', int $status = 400, array|object|null $errors = null, ?string $code = null): JsonResponse
+    {
+        $payload = [
+            'success' => false,
+            'message' => $message,
+        ];
+        if ($errors !== null) {
+            $payload['errors'] = $errors;
+        }
+        if ($code) {
+            $payload['code'] = $code;
+        }
+        return response()->json($payload, $status);
+    }
+
+    protected function paginated(LengthAwarePaginator $paginator, string $message = 'OK', int $status = 200): JsonResponse
+    {
+        return response()->json([
+            'success' => true,
+            'message' => $message,
+            'data' => $paginator->items(),
+            'meta' => [
+                'current_page' => $paginator->currentPage(),
+                'per_page' => $paginator->perPage(),
+                'total' => $paginator->total(),
+                'last_page' => $paginator->lastPage(),
+            ],
+        ], $status);
+    }
+
+    protected function exception(\Throwable $e, string $fallbackMessage = 'Erreur interne du serveur', int $status = 500): JsonResponse
+    {
+        $isDebug = (bool) config('app.debug');
+        return response()->json([
+            'success' => false,
+            'message' => $fallbackMessage,
+            'error' => $isDebug ? $e->getMessage() : null,
+        ], $status);
+    }
+}

--- a/pi-staking/apps/backend/app/Http/Controllers/Controller.php
+++ b/pi-staking/apps/backend/app/Http/Controllers/Controller.php
@@ -2,7 +2,9 @@
 
 namespace App\Http\Controllers;
 
+use App\Http\Controllers\Concerns\ApiResponses;
+
 abstract class Controller
 {
-    //
+    use ApiResponses;
 }

--- a/pi-staking/apps/backend/app/Http/Controllers/SecurityController.php
+++ b/pi-staking/apps/backend/app/Http/Controllers/SecurityController.php
@@ -8,27 +8,33 @@ use Illuminate\Http\JsonResponse;
 class SecurityController extends Controller
 {
     /**
-     * Retourne les logs de sécurité (stub)
+     * Retourne les logs de sécurité récents
      */
     public function getSecurityLogs(Request $request): JsonResponse
     {
-        return response()->json([
-            'success' => true,
-            'logs' => [], // À remplacer par la vraie logique plus tard
-        ]);
+        try {
+            $user = $request->user();
+            $logs = \App\Models\UserSecurityLog::where('user_id', $user->id)
+                ->orderByDesc('created_at')
+                ->limit(50)
+                ->get();
+
+            return $this->success(['logs' => $logs]);
+        } catch (\Throwable $e) {
+            return $this->exception($e, 'Erreur lors de la récupération des logs de sécurité');
+        }
     }
 
     public function getSecurityStats(Request $request): JsonResponse
     {
-        $user = $request->user();
-        $days = $request->query('days', 30); // Default to 30 days
-
-        $stats = \App\Models\UserSecurityLog::getSecurityStats($user->id, $days);
-        
-        return response()->json([
-            'success' => true,
-            'data' => $stats
-        ]);
+        try {
+            $user = $request->user();
+            $days = (int) $request->query('days', 30);
+            $stats = \App\Models\UserSecurityLog::getSecurityStats($user->id, $days);
+            return $this->success($stats, 'Statistiques de sécurité');
+        } catch (\Throwable $e) {
+            return $this->exception($e, 'Erreur lors de la récupération des statistiques de sécurité');
+        }
     }
 }
 

--- a/pi-staking/apps/backend/app/Http/Controllers/StakingController.php
+++ b/pi-staking/apps/backend/app/Http/Controllers/StakingController.php
@@ -22,17 +22,17 @@ class StakingController extends Controller
      */
     public function getPackages(Request $request): JsonResponse
     {
-        $user = $request->user();
-        $packages = $this->stakingService->getAvailablePackages($user);
-
-        return response()->json([
-            'success' => true,
-            'data' => [
-                'packages' => $packages->toArray(),
+        try {
+            $user = $request->user();
+            $packages = $this->stakingService->getAvailablePackages($user);
+            return $this->success([
+                'packages' => $packages,
                 'user_level' => $user->current_level,
                 'level_info' => $this->userLevelService->getLevelProgress($user),
-            ]
-        ]);
+            ]);
+        } catch (\Throwable $e) {
+            return $this->exception($e, 'Erreur lors du chargement des packages');
+        }
     }
 
     /**
@@ -54,21 +54,14 @@ class StakingController extends Controller
         ]);
 
         if ($validator->fails()) {
-            return response()->json([
-                'success' => false,
-                'message' => 'Erreurs de validation',
-                'errors' => $validator->errors()
-            ], 422);
+            return $this->fail('Erreurs de validation', 422, $validator->errors());
         }
 
         $user = $request->user();
         $package = StakingPackage::find($request->package_id);
         
         if (!$package) {
-            return response()->json([
-                'success' => false,
-                'message' => 'Package de staking introuvable.'
-            ], 404);
+            return $this->fail('Package de staking introuvable.', 404);
         }
 
         try {
@@ -81,20 +74,13 @@ class StakingController extends Controller
 
             $investment->load('stakingPackage');
 
-            return response()->json([
-                'success' => true,
-                'message' => 'Investissement créé avec succès !',
-                'data' => [
-                    'investment' => $investment,
-                    'user' => $user->fresh(['activeInvestments', 'bonusGrants']),
-                ]
-            ], 201);
+            return $this->success([
+                'investment' => $investment,
+                'user' => $user->fresh(['activeInvestments', 'bonusGrants']),
+            ], 'Investissement créé avec succès !', 201);
 
-        } catch (\Exception $e) {
-            return response()->json([
-                'success' => false,
-                'message' => $e->getMessage()
-            ], 422);
+        } catch (\Throwable $e) {
+            return $this->fail($e->getMessage(), 422);
         }
     }
 

--- a/pi-staking/apps/backend/app/Models/UserSecurityLog.php
+++ b/pi-staking/apps/backend/app/Models/UserSecurityLog.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\DB;
 
 class UserSecurityLog extends Model
 {
@@ -14,10 +15,71 @@ class UserSecurityLog extends Model
         'action',
         'ip_address',
         'user_agent',
+        'device_type',
+        'location',
+        'risk_score',
+        'severity_level',
+        'action_description',
+        'metadata',
+    ];
+
+    protected $casts = [
+        'metadata' => 'array',
+        'risk_score' => 'float',
     ];
 
     public function user()
     {
         return $this->belongsTo(User::class);
+    }
+
+    /**
+     * Statistiques de sécurité agrégées pour un utilisateur
+     */
+    public static function getSecurityStats(int $userId, int $days = 30): array
+    {
+        $startDate = now()->subDays($days);
+
+        $logs = static::where('user_id', $userId)
+            ->where('created_at', '>=', $startDate)
+            ->get();
+
+        $byDay = static::where('user_id', $userId)
+            ->where('created_at', '>=', $startDate)
+            ->selectRaw('DATE(created_at) as date, COUNT(*) as count, AVG(COALESCE(risk_score,0)) as avg_risk')
+            ->groupBy('date')
+            ->orderBy('date')
+            ->get();
+
+        $byAction = static::where('user_id', $userId)
+            ->where('created_at', '>=', $startDate)
+            ->selectRaw('action, COUNT(*) as count')
+            ->groupBy('action')
+            ->orderByDesc('count')
+            ->get();
+
+        $failedLogins = static::where('user_id', $userId)
+            ->where('created_at', '>=', $startDate)
+            ->where('action', 'failed_login')
+            ->count();
+
+        $highSeverity = static::where('user_id', $userId)
+            ->where('created_at', '>=', $startDate)
+            ->where('severity_level', 'high')
+            ->count();
+
+        return [
+            'period_days' => $days,
+            'totals' => [
+                'events' => $logs->count(),
+                'failed_logins' => $failedLogins,
+                'high_severity_events' => $highSeverity,
+                'avg_risk_score' => round((float) $logs->avg('risk_score'), 3),
+            ],
+            'by_day' => $byDay,
+            'by_action' => $byAction,
+            'recent_ips' => $logs->pluck('ip_address')->filter()->unique()->values(),
+            'recent_devices' => $logs->pluck('device_type')->filter()->unique()->values(),
+        ];
     }
 }


### PR DESCRIPTION
Standardize API responses and implement UserSecurityLog::getSecurityStats. Admin/Staking/Security controllers refactored to use ApiResponses helpers with try/catch.