### PR TITLE
Align frontend staking services with API; unify id:number and stabilize shared-types

### DIFF
--- a/pi-staking/pi-staking-frontend/src/admin/components/AdminDashboardComplete.tsx
+++ b/pi-staking/pi-staking-frontend/src/admin/components/AdminDashboardComplete.tsx
@@ -241,7 +241,7 @@ export function AdminDashboardComplete({ onLogout }: AdminDashboardCompleteProps
   const loadPackages = async () => {
     try {
       const response = await stakingService.getPackages();
-      setPackages(response.data || []);
+      setPackages(response.packages || []);
     } catch (error) {
       console.error('Erreur chargement packages:', error);
     }

--- a/pi-staking/pi-staking-frontend/src/components/StakingPackages.tsx
+++ b/pi-staking/pi-staking-frontend/src/components/StakingPackages.tsx
@@ -8,7 +8,8 @@ import { Label } from '@/components/ui/label';
 import { Slider } from '@/components/ui/slider';
 import { GlowCard } from './GlowCard';
 import { AnimatedCounter } from './AnimatedCounter';
-import { stakingService, StakingPackage } from '@/services/stakingService';
+import { stakingService } from '@/services/stakingService';
+import type { StakingPackage } from '@shared/investment';
 import { useAuth } from '@/contexts/AuthContext';
 import { 
   Loader2, 
@@ -55,13 +56,8 @@ export function StakingPackages({ onInvestmentSuccess }: StakingPackagesProps) {
       setIsLoading(true);
       setError(null);
       
-      const response = await stakingService.getPackages();
-      
-      if (response.success && response.data) {
-        setPackages(response.data.filter(pkg => pkg.is_active));
-      } else {
-        setError(response.message || 'Erreur lors du chargement des packages');
-      }
+      const { packages } = await stakingService.getPackages();
+      setPackages(packages.filter(pkg => pkg.is_active));
     } catch (err) {
       setError('Erreur de connexion au serveur');
       console.error('Packages fetch error:', err);
@@ -90,10 +86,10 @@ export function StakingPackages({ onInvestmentSuccess }: StakingPackagesProps) {
     setInvestment(prev => ({ ...prev, isLoading: true }));
 
     try {
-      const response = await stakingService.createInvestment({
-        amount: investment.amount,
-        package_id: investment.selectedPackage.id
-      });
+      const response = await stakingService.createInvestment(
+        investment.selectedPackage.id,
+        investment.amount
+      );
 
       if (response.success) {
         setInvestment(prev => ({ ...prev, step: 3, isLoading: false }));

--- a/pi-staking/pi-staking-frontend/src/components/UserDashboardComplete.tsx
+++ b/pi-staking/pi-staking-frontend/src/components/UserDashboardComplete.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { StakingPackage } from '../../../packages/shared-types/src/investment';
+import type { StakingPackage } from '@shared/investment';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
@@ -104,8 +104,8 @@ export function UserDashboardComplete({ onLogout }: UserDashboardCompleteProps) 
   const [selectedPackage, setSelectedPackage] = useState<StakingPackage | null>(null);
 
   // État pour les formulaires
-  const [investmentForm, setInvestmentForm] = useState({
-    package_id: '',
+  const [investmentForm, setInvestmentForm] = useState<{ package_id: number | null; amount: string }>({
+    package_id: null,
     amount: ''
   });
   const [withdrawalForm, setWithdrawalForm] = useState({
@@ -158,10 +158,10 @@ export function UserDashboardComplete({ onLogout }: UserDashboardCompleteProps) 
     if (!selectedPackage || !investmentForm.amount) return;
     
     try {
-      await createInvestment(selectedPackage.id.toString(), parseFloat(investmentForm.amount));
+      await createInvestment(selectedPackage.id, parseFloat(investmentForm.amount));
       
       setShowInvestModal(false);
-      setInvestmentForm({ package_id: '', amount: '' });
+      setInvestmentForm({ package_id: null, amount: '' });
       await refreshAllData();
     } catch (error) {
       console.error('Erreur investissement:', error);

--- a/pi-staking/pi-staking-frontend/src/contexts/AuthContext.tsx
+++ b/pi-staking/pi-staking-frontend/src/contexts/AuthContext.tsx
@@ -2,7 +2,7 @@ import React, { createContext, useContext, useReducer, useEffect, ReactNode } fr
 import { authService, LoginCredentials, RegisterCredentials } from '../services/authService';
 import { securityService, TwoFactorStatus, AccountSecurityStatus } from '../services/securityService';
 import { emailVerificationService, EmailVerificationResponse } from '../services/emailVerificationService';
-import type { User } from '../../../packages/shared-types/src/user.ts';
+import type { User } from '@shared/user';
 
 // Types pour l'état d'authentification
 interface AuthState {

--- a/pi-staking/pi-staking-frontend/src/contexts/StakingContext.tsx
+++ b/pi-staking/pi-staking-frontend/src/contexts/StakingContext.tsx
@@ -1,5 +1,6 @@
 import React, { createContext, useContext, useReducer, useEffect, ReactNode } from 'react';
-import { stakingService, StakingPackage, Investment, PerformanceData } from '../services/stakingService';
+import { stakingService, Investment, PerformanceData } from '../services/stakingService';
+import type { StakingPackage } from '@shared/investment';
 import { claimsService, ClaimableInvestment, ClaimStatistics, ClaimHistory } from '../services/claimsService';
 import { useAuth } from './AuthContext';
 
@@ -49,7 +50,7 @@ type StakingAction =
   | { type: 'SET_INVESTMENTS'; payload: Investment[] }
   | { type: 'SET_INVESTMENTS_LOADING'; payload: boolean }
   | { type: 'ADD_INVESTMENT'; payload: Investment }
-  | { type: 'UPDATE_INVESTMENT'; payload: { id: string; updates: Partial<Investment> } }
+  | { type: 'UPDATE_INVESTMENT'; payload: { id: number; updates: Partial<Investment> } }
   | { type: 'SET_CLAIMABLE_INVESTMENTS'; payload: ClaimableInvestment[] }
   | { type: 'SET_CLAIMABLE_LOADING'; payload: boolean }
   | { type: 'SET_CLAIM_HISTORY'; payload: ClaimHistory[] }
@@ -211,9 +212,9 @@ interface StakingContextType {
   
   // Actions des investissements
   loadInvestments: () => Promise<void>;
-  createInvestment: (packageId: string, amount: number) => Promise<boolean>;
-  getInvestmentDetails: (investmentId: string) => Promise<any>;
-  calculateEarnings: (packageId: string, amount: number, duration?: number) => Promise<any>;
+  createInvestment: (packageId: number, amount: number, source?: 'funds' | 'bonus') => Promise<boolean>;
+  getInvestmentDetails: (investmentId: number) => Promise<any>;
+  calculateEarnings: (packageId: number, amount: number, duration?: number) => Promise<any>;
   
   // Actions des réclamations
   loadClaimableInvestments: () => Promise<void>;
@@ -232,8 +233,8 @@ interface StakingContextType {
   clearError: () => void;
   
   // Getters calculés
-  getPackageById: (id: string) => StakingPackage | undefined;
-  getInvestmentById: (id: string) => Investment | undefined;
+  getPackageById: (id: number) => StakingPackage | undefined;
+  getInvestmentById: (id: number) => Investment | undefined;
   getClaimableByInvestmentId: (investmentId: string) => ClaimableInvestment | undefined;
   getTotalROI: () => number;
   getAverageDailyReturn: () => number;
@@ -299,13 +300,8 @@ export const StakingProvider: React.FC<StakingProviderProps> = ({ children }) =>
   const loadPackages = async (): Promise<void> => {
     try {
       dispatch({ type: 'SET_PACKAGES_LOADING', payload: true });
-      const response = await stakingService.getPackages();
-      
-      if (response.success) {
-        dispatch({ type: 'SET_PACKAGES', payload: response.data });
-      } else {
-        throw new Error('Erreur de chargement des packages');
-      }
+      const { packages } = await stakingService.getPackages();
+      dispatch({ type: 'SET_PACKAGES', payload: packages });
     } catch (error) {
       console.error('Erreur lors du chargement des packages:', error);
       dispatch({ type: 'SET_ERROR', payload: 'Erreur de chargement des packages' });
@@ -334,15 +330,18 @@ export const StakingProvider: React.FC<StakingProviderProps> = ({ children }) =>
   };
 
   // Créer un investissement
-  const createInvestment = async (packageId: string, amount: number): Promise<boolean> => {
+  const createInvestment = async (
+    packageId: number,
+    amount: number,
+    source: 'funds' | 'bonus' = 'funds'
+  ): Promise<boolean> => {
     try {
       dispatch({ type: 'SET_LOADING', payload: true });
-      const response = await stakingService.createInvestment(packageId, amount);
+      const response = await stakingService.createInvestment(packageId, amount, source);
       
       if (response.success) {
         dispatch({ type: 'ADD_INVESTMENT', payload: response.data });
         
-        // Recharger les données liées
         await Promise.all([
           loadClaimableInvestments(),
           loadClaimStatistics()
@@ -354,7 +353,7 @@ export const StakingProvider: React.FC<StakingProviderProps> = ({ children }) =>
         return false;
       }
     } catch (error) {
-      const message = error instanceof Error ? error.message : 'Erreur de création d\'investissement';
+      const message = error instanceof Error ? error.message : "Erreur de création d'investissement";
       dispatch({ type: 'SET_ERROR', payload: message });
       return false;
     } finally {
@@ -363,17 +362,16 @@ export const StakingProvider: React.FC<StakingProviderProps> = ({ children }) =>
   };
 
   // Obtenir les détails d'un investissement
-  const getInvestmentDetails = async (investmentId: string) => {
+  const getInvestmentDetails = async (investmentId: number) => {
     try {
       const response = await stakingService.getInvestmentDetails(investmentId);
       if (response.success) {
-        // Mettre à jour l'investissement dans l'état
         dispatch({
           type: 'UPDATE_INVESTMENT',
           payload: {
             id: investmentId,
-            updates: response.data
-          }
+            updates: response.data,
+          },
         });
         return response.data;
       } else {
@@ -386,7 +384,7 @@ export const StakingProvider: React.FC<StakingProviderProps> = ({ children }) =>
   };
 
   // Calculer les gains
-  const calculateEarnings = async (packageId: string, amount: number, duration?: number) => {
+  const calculateEarnings = async (packageId: number, amount: number, duration?: number) => {
     try {
       const response = await stakingService.calculateEarnings(packageId, amount, duration);
       return response.success ? response.data : null;
@@ -588,11 +586,11 @@ export const StakingProvider: React.FC<StakingProviderProps> = ({ children }) =>
   };
 
   // Getters calculés
-  const getPackageById = (id: string): StakingPackage | undefined => {
+  const getPackageById = (id: number): StakingPackage | undefined => {
     return state.packages.find(pkg => pkg.id === id);
   };
 
-  const getInvestmentById = (id: string): Investment | undefined => {
+  const getInvestmentById = (id: number): Investment | undefined => {
     return state.investments.find(inv => inv.id === id);
   };
 

--- a/pi-staking/pi-staking-frontend/src/services/authService.ts
+++ b/pi-staking/pi-staking-frontend/src/services/authService.ts
@@ -1,5 +1,5 @@
 import apiClient, { sanctumClient } from '@/lib/api-enhanced';
-import type { User } from '../../../packages/shared-types/src/user.ts';
+import type { User } from '@shared/user';
 
 export interface LoginCredentials {
   email: string;

--- a/pi-staking/pi-staking-frontend/src/services/stakingService.ts
+++ b/pi-staking/pi-staking-frontend/src/services/stakingService.ts
@@ -1,26 +1,10 @@
 import api from '../lib/api-enhanced';
-
-// Types pour le staking
-export interface StakingPackage {
-  id: string;
-  name: string;
-  description: string;
-  level: 'discovery' | 'bronze' | 'silver' | 'gold' | 'diamond';
-  daily_rate: number;
-  min_amount: number;
-  max_amount: number | null;
-  max_duration_days: number;
-  deposit_fee_rate: number;
-  performance_fee_rate: number;
-  is_active: boolean;
-  created_at: string;
-  updated_at: string;
-}
+import type { StakingPackage } from '@shared/investment';
 
 export interface Investment {
-  id: string;
-  user_id: string;
-  staking_package_id: string;
+  id: number;
+  user_id: number;
+  staking_package_id: number;
   amount: number;
   daily_rate: number;
   total_earned: number;
@@ -52,37 +36,35 @@ export interface EarningsCalculation {
 }
 
 class StakingService {
-  
-  // Récupérer tous les packages de staking disponibles
-  async getPackages(): Promise<{ success: boolean; data: StakingPackage[] }> {
+  async getPackages(): Promise<{ packages: StakingPackage[]; user_level: string; level_info: any }> {
     try {
       const response = await api.get('/staking/packages');
-      return response.data;
+      const { packages, user_level, level_info } = response?.data?.data || {};
+      return { packages: packages || [], user_level, level_info };
     } catch (error) {
       console.error('Erreur lors de la récupération des packages:', error);
       throw error;
     }
   }
 
-  // Créer un nouvel investissement
-  async createInvestment(packageId: string, amount: number): Promise<{ 
-    success: boolean; 
-    data: Investment; 
-    message: string; 
-  }> {
+  async createInvestment(
+    packageId: number,
+    amount: number,
+    source: 'funds' | 'bonus' = 'funds'
+  ): Promise<{ success: boolean; data: Investment; message: string }> {
     try {
       const response = await api.post('/staking/invest', {
-        staking_package_id: packageId,
-        amount
+        package_id: packageId,
+        amount,
+        source,
       });
       return response.data;
     } catch (error) {
-      console.error('Erreur lors de la création de l\'investissement:', error);
+      console.error("Erreur lors de la création de l'investissement:", error);
       throw error;
     }
   }
 
-  // Récupérer les investissements de l'utilisateur
   async getUserInvestments(): Promise<{ success: boolean; data: Investment[] }> {
     try {
       const response = await api.get('/staking/investments');
@@ -93,35 +75,36 @@ class StakingService {
     }
   }
 
-  // Récupérer les détails d'un investissement spécifique
-  async getInvestmentDetails(investmentId: string): Promise<{ 
-    success: boolean; 
+  async getInvestmentDetails(
+    investmentId: number
+  ): Promise<{
+    success: boolean;
     data: Investment & {
       claimable_amount: number;
       days_remaining: number;
       total_days: number;
       progress_percentage: number;
-    }
+    };
   }> {
     try {
       const response = await api.get(`/staking/investment/${investmentId}`);
       return response.data;
     } catch (error) {
-      console.error('Erreur lors de la récupération des détails de l\'investissement:', error);
+      console.error("Erreur lors de la récupération des détails de l'investissement:", error);
       throw error;
     }
   }
 
-  // Calculer les gains potentiels pour un investissement
-  async calculateEarnings(packageId: string, amount: number, duration?: number): Promise<{ 
-    success: boolean; 
-    data: EarningsCalculation 
-  }> {
+  async calculateEarnings(
+    packageId: number,
+    amount: number,
+    duration?: number
+  ): Promise<{ success: boolean; data: EarningsCalculation }> {
     try {
       const response = await api.post('/staking/calculate-earnings', {
-        staking_package_id: packageId,
+        package_id: packageId,
         amount,
-        duration_days: duration
+        duration_days: duration,
       });
       return response.data;
     } catch (error) {
@@ -130,21 +113,24 @@ class StakingService {
     }
   }
 
-  // Récupérer l'historique de performance
-  async getPerformanceHistory(period: 'week' | 'month' | 'year' = 'month'): Promise<{ 
-    success: boolean; 
-    data: PerformanceData[] 
-  }> {
+  async getPerformanceHistory(
+    period: 'week' | 'month' | 'year' = 'month'
+  ): Promise<{ success: boolean; data: PerformanceData[] }> {
     try {
-      const response = await api.get(`/staking/performance?period=${period}`);
+      const periodMap: Record<'week' | 'month' | 'year', string> = {
+        week: '7days',
+        month: '30days',
+        year: '1year',
+      };
+      const apiPeriod = periodMap[period];
+      const response = await api.get(`/staking/performance?period=${apiPeriod}`);
       return response.data;
     } catch (error) {
-      console.error('Erreur lors de la récupération de l\'historique de performance:', error);
+      console.error("Erreur lors de la récupération de l'historique de performance:", error);
       throw error;
     }
   }
 
-  // Calculer les statistiques de staking pour l'utilisateur
   async getStakingStats(): Promise<{
     success: boolean;
     data: {
@@ -156,10 +142,9 @@ class StakingService {
       average_daily_return: number;
       best_package: string;
       total_profit_percentage: number;
-    }
+    };
   }> {
     try {
-      // On utilise les investissements pour calculer les stats côté client
       const investmentsResponse = await this.getUserInvestments();
       if (!investmentsResponse.success) throw new Error('Impossible de récupérer les investissements');
 
@@ -167,13 +152,12 @@ class StakingService {
       const totalInvested = investments.reduce((sum, inv) => sum + inv.amount, 0);
       const totalEarned = investments.reduce((sum, inv) => sum + inv.total_earned, 0);
       const totalClaimed = investments.reduce((sum, inv) => sum + inv.total_claimed, 0);
-      const activeInvestments = investments.filter(inv => inv.status === 'active').length;
-      const completedInvestments = investments.filter(inv => inv.status === 'completed').length;
+      const activeInvestments = investments.filter((inv) => inv.status === 'active').length;
+      const completedInvestments = investments.filter((inv) => inv.status === 'completed').length;
 
-      // Calculer le retour quotidien moyen
       const totalDailyReturns = investments.reduce((sum, inv) => {
         if (inv.status === 'active') {
-          const dailyReturn = (inv.amount * inv.daily_rate);
+          const dailyReturn = inv.amount * inv.daily_rate;
           return sum + dailyReturn;
         }
         return sum;
@@ -181,14 +165,13 @@ class StakingService {
 
       const averageDailyReturn = activeInvestments > 0 ? totalDailyReturns / activeInvestments : 0;
 
-      // Trouver le meilleur package (celui avec le plus d'investissements)
       const packageCounts = investments.reduce((acc, inv) => {
         const packageName = inv.package?.name || 'Inconnu';
         acc[packageName] = (acc[packageName] || 0) + 1;
         return acc;
       }, {} as Record<string, number>);
 
-      const bestPackage = Object.entries(packageCounts).reduce((a, b) => 
+      const bestPackage = Object.entries(packageCounts).reduce((a, b) =>
         packageCounts[a[0]] > packageCounts[b[0]] ? a : b
       )[0] || 'Aucun';
 
@@ -204,8 +187,8 @@ class StakingService {
           completed_investments: completedInvestments,
           average_daily_return: averageDailyReturn,
           best_package: bestPackage,
-          total_profit_percentage: totalProfitPercentage
-        }
+          total_profit_percentage: totalProfitPercentage,
+        },
       };
     } catch (error) {
       console.error('Erreur lors du calcul des statistiques de staking:', error);

--- a/pi-staking/pi-staking-frontend/tsconfig.json
+++ b/pi-staking/pi-staking-frontend/tsconfig.json
@@ -2,7 +2,8 @@
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": ["./src/*"],
+      "@shared/*": ["../packages/shared-types/src/*"]
     },
     "target": "ES2020",
     "useDefineForClassFields": true,

--- a/pi-staking/pi-staking-frontend/vite.config.ts
+++ b/pi-staking/pi-staking-frontend/vite.config.ts
@@ -20,9 +20,13 @@ export default defineConfig({
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),
+      "@shared": path.resolve(__dirname, "../packages/shared-types/src"),
     },
   },
   server: {
+    fs: {
+      allow: [path.resolve(__dirname, "..")]
+    },
     proxy: {
       '/api': {
         target: 'http://localhost:8000',


### PR DESCRIPTION
Summary\n- Align frontend services with Laravel API contract.\n\nKey changes\n- stakingService.getPackages now returns { packages, user_level, level_info } from response.data.data.\n- Consumers updated: StakingContext.loadPackages(), StakingPackages, and AdminDashboardComplete no longer assume an array at response.data.\n- createInvestment signature unified: (packageId: number, amount: number, source: 'funds' | 'bonus' = 'funds').\n- Payload now matches backend: { package_id, amount, source } to POST /staking/invest.\n- getPerformanceHistory maps period to backend values: week→7days, month→30days, year→1year.\n- Type unification: StakingPackage.id is number across services/contexts/components. StakingPackage imported from @shared/investment.\n- Kept a local Investment UI type (id:number) to preserve current fields (e.g., total_earned, total_claimed) pending backend alignment.\n\nShared-types stabilization\n- Added @shared alias in Vite (and server.fs.allow) and tsconfig paths.\n- Replaced relative imports with @shared/... in UserDashboardComplete, AuthContext, and authService.\n\nFiles touched\n- pi-staking-frontend/src/services/stakingService.ts\n- pi-staking-frontend/src/contexts/StakingContext.tsx\n- pi-staking-frontend/src/components/StakingPackages.tsx\n- pi-staking-frontend/src/components/UserDashboardComplete.tsx\n- pi-staking-frontend/src/contexts/AuthContext.tsx\n- pi-staking-frontend/src/services/authService.ts\n- pi-staking-frontend/vite.config.ts\n- pi-staking-frontend/tsconfig.json\n- pi-staking-frontend/src/admin/components/AdminDashboardComplete.tsx\n\nManual test notes\n- getPackages() returns object; lists render without filtering on an object.\n- createInvestment(123, 1000) posts { package_id:123, amount:1000, source:'funds' }.\n- performance history calls /staking/performance?period=7days|30days|1year.\n\nLong-term\n- Consider building packages/shared-types to emit JS + d.ts and consume as a package (e.g., @pi-staking/shared-types).

₍ᐢ•(ܫ)•ᐢ₎ Generated by [Scout](https://scout.new) ([view task](https://scout.new/project/57292751-84af-11f0-a94e-3eef481a796b/task/95a2efc9-27b5-4d46-b6de-a79ee438e8b5))