### PR TITLE
Register Spatie role/permission middleware aliases in bootstrap

### DIFF
--- a/pi-staking/apps/backend/README.md
+++ b/pi-staking/apps/backend/README.md
@@ -1,0 +1,26 @@
+Laravel 11 middleware aliases
+
+In Laravel 11, route middleware aliases must be registered in `bootstrap/app.php` inside the `withMiddleware(...)` closure. The `$routeMiddleware` map in `app/Http/Kernel.php` is no longer used for alias registration.
+
+This app uses Spatie\Permission. The aliases are defined as follows (plus the existing `anti-abuse` alias):
+
+```
+->withMiddleware(function (Middleware $middleware) {
+    $middleware->alias([
+        'anti-abuse' => \App\Http\Middleware\AntiAbuseMiddleware::class,
+        'role' => \Spatie\Permission\Middlewares\RoleMiddleware::class,
+        'permission' => \Spatie\Permission\Middlewares\PermissionMiddleware::class,
+        'role_or_permission' => \Spatie\Permission\Middlewares\RoleOrPermissionMiddleware::class,
+    ]);
+
+    $middleware->statefulApi();
+})
+```
+
+After changes, clear caches so aliases are picked up:
+
+```
+php artisan optimize:clear
+php artisan route:clear
+php artisan config:clear
+```

--- a/pi-staking/apps/backend/bootstrap/app.php
+++ b/pi-staking/apps/backend/bootstrap/app.php
@@ -15,6 +15,9 @@ return Application::configure(basePath: dirname(__DIR__))
         // Enregistrer le middleware anti-abus
         $middleware->alias([
             'anti-abuse' => \App\Http\Middleware\AntiAbuseMiddleware::class,
+            'role' => \Spatie\Permission\Middlewares\RoleMiddleware::class,
+            'permission' => \Spatie\Permission\Middlewares\PermissionMiddleware::class,
+            'role_or_permission' => \Spatie\Permission\Middlewares\RoleOrPermissionMiddleware::class,
         ]);
         
         // Appliquer Sanctum aux routes API


### PR DESCRIPTION
Fixes 500 'Target class [role] does not exist' by registering Spatie middleware aliases in Laravel 11's bootstrap/app.php.\n\nChanges:\n- Add middleware aliases in bootstrap/app.php: role, permission, role_or_permission.\n- Preserve existing 'anti-abuse' alias and statefulApi() call.\n- Add apps/backend/README.md noting Laravel 11 alias registration location.\n\nVerification steps:\n1) Clear caches: php artisan config:clear && php artisan route:clear (optimize:clear optional).\n2) Ensure an admin role exists and assign to a user (AdminUserSeeder included).\n3) With Sanctum token for admin: GET /api/admin/dashboard => 200.\n4) With non-admin token: same endpoint => 403.\n5) Unauthenticated => 401.\n\nScope: backend only (apps/backend).

₍ᐢ•(ܫ)•ᐢ₎ Generated by [Scout](https://scout.new) ([view task](https://scout.new/project/57292751-84af-11f0-a94e-3eef481a796b/task/eaa7a117-3bd4-4afa-8160-b23d45283c47))