### PR TITLE
Phase 1: Backend PI deposit flow — address reservation, watcher, API

### DIFF
--- a/pi-staking/apps/backend/app/Console/Commands/ScanPiDeposits.php
+++ b/pi-staking/apps/backend/app/Console/Commands/ScanPiDeposits.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use App\Services\DepositWatcher\DepositWatcherService;
+
+class ScanPiDeposits extends Command
+{
+    protected $signature = 'pi:scan-deposits';
+
+    protected $description = 'Scanner les dépôts Pi entrants et mettre à jour les statuts';
+
+    public function handle(DepositWatcherService $service)
+    {
+        $service->scan();
+        $this->info('Scan des dépôts Pi terminé');
+        return self::SUCCESS;
+    }
+}

--- a/pi-staking/apps/backend/app/Console/Kernel.php
+++ b/pi-staking/apps/backend/app/Console/Kernel.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Console;
+
+use Illuminate\Console\Scheduling\Schedule;
+use Illuminate\Foundation\Console\Kernel as ConsoleKernel;
+
+class Kernel extends ConsoleKernel
+{
+    protected function schedule(Schedule $schedule): void
+    {
+        $schedule->command('pi:scan-deposits')->everyMinute();
+    }
+
+    protected function commands(): void
+    {
+        $this->load(__DIR__.'/Commands');
+        require base_path('routes/console.php');
+    }
+}

--- a/pi-staking/apps/backend/app/Http/Controllers/DepositController.php
+++ b/pi-staking/apps/backend/app/Http/Controllers/DepositController.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Deposit;
+use App\Services\DepositService;
+use Illuminate\Http\Request;
+use Illuminate\Http\JsonResponse;
+
+class DepositController extends Controller
+{
+    public function __construct(private DepositService $depositService)
+    {
+    }
+
+    public function requestAddress(Request $request): JsonResponse
+    {
+        $user = $request->user();
+        try {
+            $result = $this->depositService->assignAddressForUser($user);
+            return response()->json([
+                'success' => true,
+                'data' => [
+                    'id' => $result['id'],
+                    'address' => $result['address'],
+                    'expires_at' => $result['expires_at'],
+                ],
+            ]);
+        } catch (\Exception $e) {
+            $message = $e->getMessage();
+            $code = str_contains($message, 'déjà attribuée') ? 409 : (str_contains($message, 'Aucune adresse') ? 429 : 400);
+            return response()->json([
+                'success' => false,
+                'message' => $message,
+            ], $code);
+        }
+    }
+
+    public function status(Request $request, int $id): JsonResponse
+    {
+        $user = $request->user();
+        $deposit = Deposit::with('address')->where('id', $id)->where('user_id', $user->id)->firstOrFail();
+
+        if ($deposit->status === Deposit::STATUS_PENDING) {
+            $addr = $deposit->address;
+            if ($addr && $addr->expires_at && now()->greaterThan($addr->expires_at)) {
+                $deposit->status = Deposit::STATUS_EXPIRED;
+                $deposit->save();
+            }
+        }
+
+        return response()->json([
+            'success' => true,
+            'data' => [
+                'status' => $deposit->status,
+                'amount' => $deposit->amount,
+                'tx_hash' => $deposit->tx_hash,
+                'expires_at' => optional($deposit->address)->expires_at,
+                'address' => optional($deposit->address)->address,
+            ],
+        ]);
+    }
+}

--- a/pi-staking/apps/backend/app/Models/Deposit.php
+++ b/pi-staking/apps/backend/app/Models/Deposit.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class Deposit extends Model
+{
+    use HasFactory;
+
+    const STATUS_PENDING = 'pending';
+    const STATUS_CONFIRMED = 'confirmed';
+    const STATUS_EXPIRED = 'expired';
+    const STATUS_FAILED = 'failed';
+
+    protected $fillable = [
+        'user_id',
+        'address_id',
+        'amount',
+        'tx_hash',
+        'status',
+        'confirmed_at',
+    ];
+
+    protected $casts = [
+        'amount' => 'decimal:8',
+        'confirmed_at' => 'datetime',
+    ];
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function address(): BelongsTo
+    {
+        return $this->belongsTo(DepositAddress::class, 'address_id');
+    }
+}

--- a/pi-staking/apps/backend/app/Models/DepositAddress.php
+++ b/pi-staking/apps/backend/app/Models/DepositAddress.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class DepositAddress extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'address',
+        'is_active',
+        'assigned_to_user_id',
+        'assigned_at',
+        'expires_at',
+    ];
+
+    protected $casts = [
+        'is_active' => 'boolean',
+        'assigned_at' => 'datetime',
+        'expires_at' => 'datetime',
+    ];
+
+    public function assignedTo(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'assigned_to_user_id');
+    }
+
+    public function deposits(): HasMany
+    {
+        return $this->hasMany(Deposit::class, 'address_id');
+    }
+
+    public function scopeFree($query)
+    {
+        return $query->where('is_active', true)->whereNull('assigned_to_user_id');
+    }
+
+    public function scopeExpiredReservations($query)
+    {
+        return $query->where('is_active', true)
+            ->whereNotNull('expires_at')
+            ->where('expires_at', '<=', now());
+    }
+}

--- a/pi-staking/apps/backend/app/Services/DepositService.php
+++ b/pi-staking/apps/backend/app/Services/DepositService.php
@@ -1,0 +1,166 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Deposit;
+use App\Models\DepositAddress;
+use App\Models\Transaction;
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Exception;
+
+class DepositService
+{
+    public function assignAddressForUser(User $user): array
+    {
+        return DB::transaction(function () use ($user) {
+            $this->releaseExpiredReservations();
+
+            $policy = config('deposits.policy_on_rerequest', 'refuse');
+            if ($policy === 'refuse') {
+                $existing = Deposit::query()
+                    ->where('user_id', $user->id)
+                    ->where('status', Deposit::STATUS_PENDING)
+                    ->whereHas('address', function ($q) {
+                        $q->whereNotNull('assigned_to_user_id')
+                          ->where('expires_at', '>', now());
+                    })
+                    ->latest('id')
+                    ->first();
+
+                if ($existing) {
+                    $expires = optional($existing->address)->expires_at;
+                    throw new Exception('Une adresse vous est déjà attribuée jusqu\'à ' . ($expires ? $expires->toDateTimeString() : 'expiration'));
+                }
+            }
+
+            $address = DepositAddress::query()
+                ->free()
+                ->orderBy('id')
+                ->lockForUpdate()
+                ->first();
+
+            if (!$address) {
+                throw new Exception('Aucune adresse de dépôt n\'est disponible pour le moment');
+            }
+
+            $ttl = (int) config('deposits.reservation_ttl_minutes', 15);
+            $address->assigned_to_user_id = $user->id;
+            $address->assigned_at = now();
+            $address->expires_at = now()->clone()->addMinutes($ttl);
+            $address->save();
+
+            $deposit = Deposit::create([
+                'user_id' => $user->id,
+                'address_id' => $address->id,
+                'amount' => null,
+                'tx_hash' => null,
+                'status' => Deposit::STATUS_PENDING,
+                'confirmed_at' => null,
+            ]);
+
+            return [
+                'id' => $deposit->id,
+                'address' => $address->address,
+                'expires_at' => $address->expires_at,
+            ];
+        });
+    }
+
+    public function releaseExpiredReservations(): void
+    {
+        DB::transaction(function () {
+            $expiredAddresses = DepositAddress::expiredReservations()->lockForUpdate()->get();
+
+            foreach ($expiredAddresses as $addr) {
+                Deposit::where('address_id', $addr->id)
+                    ->where('status', Deposit::STATUS_PENDING)
+                    ->update(['status' => Deposit::STATUS_EXPIRED]);
+
+                $addr->assigned_to_user_id = null;
+                $addr->assigned_at = null;
+                $addr->expires_at = null;
+                $addr->save();
+            }
+        });
+    }
+
+    public function handleDetectedTransaction(string $address, string $txHash, string $amount, int $confirmations): void
+    {
+        DB::transaction(function () use ($address, $txHash, $amount, $confirmations) {
+            $addr = DepositAddress::query()->where('address', $address)->lockForUpdate()->first();
+            if (!$addr) {
+                Log::warning('Transaction détectée pour une adresse inconnue', ['address' => $address, 'tx' => $txHash]);
+                return;
+            }
+
+            $deposit = Deposit::query()
+                ->where('address_id', $addr->id)
+                ->where('status', Deposit::STATUS_PENDING)
+                ->latest('id')
+                ->first();
+
+            if (!$deposit) {
+                return;
+            }
+
+            $minConf = (int) config('deposits.confirmations_required', 1);
+
+            if ($addr->expires_at && now()->greaterThan($addr->expires_at)) {
+                $deposit->status = Deposit::STATUS_EXPIRED;
+                $deposit->save();
+                return;
+            }
+
+            if ($confirmations < $minConf) {
+                return;
+            }
+
+            $amountF = (float) $amount;
+            $min = (float) config('deposits.deposit_min', 10);
+            $max = (float) config('deposits.deposit_max', 5000);
+
+            $deposit->amount = $amountF;
+            $deposit->tx_hash = $txHash;
+
+            if ($amountF < $min || $amountF > $max) {
+                $deposit->status = Deposit::STATUS_FAILED;
+                $deposit->confirmed_at = now();
+                $deposit->save();
+                Log::warning('Dépôt en dehors des limites', ['deposit_id' => $deposit->id, 'amount' => $amountF]);
+                return;
+            }
+
+            $deposit->status = Deposit::STATUS_CONFIRMED;
+            $deposit->confirmed_at = now();
+            $deposit->save();
+
+            $user = $deposit->user;
+            $before = $user->balance_pi;
+            $user->increment('balance_pi', $amountF);
+
+            Transaction::create([
+                'user_id' => $user->id,
+                'type' => 'deposit',
+                'category' => 'deposit',
+                'amount' => $amountF,
+                'balance_before' => $before,
+                'balance_after' => $before + $amountF,
+                'status' => 'completed',
+                'reference_id' => (string) $deposit->id,
+                'transaction_hash' => $txHash,
+                'description' => 'Dépôt Pi confirmé',
+                'processed_at' => now(),
+            ]);
+
+            Log::channel('daily')->info('Dépôt confirmé', [
+                'deposit_id' => $deposit->id,
+                'user_id' => $user->id,
+                'amount' => $amountF,
+                'tx_hash' => $txHash,
+            ]);
+        });
+    }
+}

--- a/pi-staking/apps/backend/app/Services/DepositWatcher/ApiProvider.php
+++ b/pi-staking/apps/backend/app/Services/DepositWatcher/ApiProvider.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Services\DepositWatcher;
+
+use Illuminate\Support\Facades\Http;
+
+class ApiProvider implements PiDepositProviderInterface
+{
+    public function findIncomingForAddresses(array $addresses): array
+    {
+        $url = config('deposits.pi_api_url');
+        $key = config('deposits.pi_api_key');
+        if (!$url || !$key) {
+            return [];
+        }
+
+        try {
+            $response = Http::withHeaders([
+                'Authorization' => 'Bearer ' . $key,
+                'Accept' => 'application/json',
+            ])->post(rtrim($url, '/') . '/incoming', [
+                'addresses' => array_values($addresses),
+            ]);
+
+            if (!$response->ok()) {
+                return [];
+            }
+
+            $data = $response->json();
+            return is_array($data) ? $data : [];
+        } catch (\Throwable $e) {
+            return [];
+        }
+    }
+}

--- a/pi-staking/apps/backend/app/Services/DepositWatcher/DepositWatcherService.php
+++ b/pi-staking/apps/backend/app/Services/DepositWatcher/DepositWatcherService.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Services\DepositWatcher;
+
+use App\Models\DepositAddress;
+use App\Services\DepositService;
+
+class DepositWatcherService
+{
+    public function __construct(private DepositService $depositService)
+    {
+    }
+
+    public function scan(): void
+    {
+        $addresses = DepositAddress::query()
+            ->where('is_active', true)
+            ->whereNotNull('assigned_to_user_id')
+            ->where('expires_at', '>', now())
+            ->pluck('address')
+            ->all();
+
+        if (empty($addresses)) {
+            return;
+        }
+
+        $provider = $this->makeProvider();
+        $hits = $provider->findIncomingForAddresses($addresses);
+
+        foreach ($hits as $hit) {
+            $addr = $hit['address'] ?? null;
+            $tx = $hit['tx_hash'] ?? null;
+            $amount = (string) ($hit['amount'] ?? '0');
+            $conf = (int) ($hit['confirmations'] ?? 0);
+            if ($addr && $tx) {
+                $this->depositService->handleDetectedTransaction($addr, $tx, $amount, $conf);
+            }
+        }
+    }
+
+    private function makeProvider(): PiDepositProviderInterface
+    {
+        $key = config('deposits.provider', 'testnet');
+        return match ($key) {
+            'sdk' => new SdkProvider(),
+            'api' => new ApiProvider(),
+            default => new TestnetProvider(),
+        };
+    }
+}

--- a/pi-staking/apps/backend/app/Services/DepositWatcher/PiDepositProviderInterface.php
+++ b/pi-staking/apps/backend/app/Services/DepositWatcher/PiDepositProviderInterface.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace App\Services\DepositWatcher;
+
+interface PiDepositProviderInterface
+{
+    public function findIncomingForAddresses(array $addresses): array;
+}

--- a/pi-staking/apps/backend/app/Services/DepositWatcher/SdkProvider.php
+++ b/pi-staking/apps/backend/app/Services/DepositWatcher/SdkProvider.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Services\DepositWatcher;
+
+class SdkProvider implements PiDepositProviderInterface
+{
+    public function findIncomingForAddresses(array $addresses): array
+    {
+        return [];
+    }
+}

--- a/pi-staking/apps/backend/app/Services/DepositWatcher/TestnetProvider.php
+++ b/pi-staking/apps/backend/app/Services/DepositWatcher/TestnetProvider.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Services\DepositWatcher;
+
+class TestnetProvider implements PiDepositProviderInterface
+{
+    public function findIncomingForAddresses(array $addresses): array
+    {
+        return [];
+    }
+}

--- a/pi-staking/apps/backend/config/deposits.php
+++ b/pi-staking/apps/backend/config/deposits.php
@@ -1,0 +1,12 @@
+<?php
+
+return [
+    'provider' => env('DEPOSITS_PROVIDER', 'testnet'),
+    'reservation_ttl_minutes' => (int) env('DEPOSITS_RESERVATION_TTL', 15),
+    'confirmations_required' => (int) env('DEPOSITS_CONFIRMATIONS', 1),
+    'deposit_min' => (float) env('DEPOSITS_MIN', 10),
+    'deposit_max' => (float) env('DEPOSITS_MAX', 5000),
+    'policy_on_rerequest' => env('DEPOSITS_POLICY_ON_REREQUEST', 'refuse'),
+    'pi_api_url' => env('PI_API_URL'),
+    'pi_api_key' => env('PI_API_KEY'),
+];

--- a/pi-staking/apps/backend/database/migrations/2025_09_10_100000_create_deposit_addresses_table.php
+++ b/pi-staking/apps/backend/database/migrations/2025_09_10_100000_create_deposit_addresses_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('deposit_addresses', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('address')->unique();
+            $table->boolean('is_active')->default(true);
+            $table->foreignId('assigned_to_user_id')->nullable()->constrained('users')->nullOnDelete();
+            $table->timestamp('assigned_at')->nullable();
+            $table->timestamp('expires_at')->nullable();
+            $table->timestamps();
+
+            $table->index(['is_active', 'expires_at', 'assigned_to_user_id']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('deposit_addresses');
+    }
+};

--- a/pi-staking/apps/backend/database/migrations/2025_09_10_100100_create_deposits_table.php
+++ b/pi-staking/apps/backend/database/migrations/2025_09_10_100100_create_deposits_table.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('deposits', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->foreignId('user_id')->constrained('users')->cascadeOnDelete();
+            $table->foreignId('address_id')->constrained('deposit_addresses')->cascadeOnDelete();
+            $table->decimal('amount', 20, 8)->nullable();
+            $table->string('tx_hash')->nullable()->unique();
+            $table->enum('status', ['pending', 'confirmed', 'expired', 'failed'])->default('pending');
+            $table->timestamp('confirmed_at')->nullable();
+            $table->timestamps();
+
+            $table->index(['status', 'user_id', 'address_id', 'tx_hash']);
+        });
+
+        // Optional check constraint for amount >= 0 when supported
+        try {
+            $driver = Schema::getConnection()->getDriverName();
+            if (in_array($driver, ['mysql', 'pgsql', 'sqlite'])) {
+                Schema::table('deposits', function (Blueprint $table) {
+                    $table->check('amount IS NULL OR amount >= 0');
+                });
+            }
+        } catch (\Throwable $e) {
+        }
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('deposits');
+    }
+};

--- a/pi-staking/apps/backend/database/seeders/DatabaseSeeder.php
+++ b/pi-staking/apps/backend/database/seeders/DatabaseSeeder.php
@@ -3,25 +3,19 @@
 namespace Database\Seeders;
 
 use App\Models\User;
-// use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 
 class DatabaseSeeder extends Seeder
 {
-    /**
-     * Seed the application's database.
-     */
     public function run(): void
     {
-        // Créer les packages de staking
         $this->call([
             InitialStakingPackagesSeeder::class,
+            DepositAddressesSeeder::class,
             AdminUserSeeder::class,
         ]);
-        
-        // Optionnel : créer des utilisateurs factices pour les tests
+
         if (app()->environment(['local', 'development'])) {
-            // User::factory(50)->create();
         }
     }
 }

--- a/pi-staking/apps/backend/database/seeders/DepositAddressesSeeder.php
+++ b/pi-staking/apps/backend/database/seeders/DepositAddressesSeeder.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
+use Illuminate\Support\Facades\DB;
+
+class DepositAddressesSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $raw = env('STAKING_PI_SEED_ADDRESSES');
+        if (!$raw) {
+            Log::warning('STAKING_PI_SEED_ADDRESSES is empty; no deposit addresses seeded');
+            return;
+        }
+
+        $addresses = collect(explode(',', $raw))
+            ->map(fn ($a) => trim($a))
+            ->filter(fn ($a) => $a !== '')
+            ->unique()
+            ->values();
+
+        if ($addresses->isEmpty()) {
+            Log::warning('STAKING_PI_SEED_ADDRESSES parsed empty after trimming; no deposit addresses seeded');
+            return;
+        }
+
+        $now = now();
+
+        foreach ($addresses as $address) {
+            $exists = DB::table('deposit_addresses')->where('address', $address)->exists();
+            if (!$exists) {
+                DB::table('deposit_addresses')->insert([
+                    'address' => $address,
+                    'is_active' => true,
+                    'assigned_to_user_id' => null,
+                    'assigned_at' => null,
+                    'expires_at' => null,
+                    'created_at' => $now,
+                    'updated_at' => $now,
+                ]);
+            }
+        }
+    }
+}

--- a/pi-staking/apps/backend/routes/api.php
+++ b/pi-staking/apps/backend/routes/api.php
@@ -11,6 +11,7 @@ use App\Http\Controllers\AdminController;
 use App\Http\Controllers\SecurityController;
 use App\Http\Controllers\ReferralController;
 use App\Http\Controllers\AdminReferralController;
+use App\Http\Controllers\DepositController;
 
 /*
 |--------------------------------------------------------------------------
@@ -72,6 +73,12 @@ Route::middleware('auth:sanctum')->group(function () {
         Route::get('/statistics', [ClaimController::class, 'getClaimStatistics']);
         Route::post('/bulk-claim', [ClaimController::class, 'bulkClaim']);
         Route::post('/simulate-earnings', [ClaimController::class, 'simulateEarnings']);
+    });
+
+    // Dépôts Pi
+    Route::prefix('deposit')->group(function () {
+        Route::post('/request', [DepositController::class, 'requestAddress']);
+        Route::get('/status/{id}', [DepositController::class, 'status']);
     });
 
     // Gestion des transactions


### PR DESCRIPTION
This PR implements the Phase 1 backend flow for PI deposits with address reservation, pluggable watcher, API endpoints, and scheduling.

Key changes
- Migrations:
  - deposit_addresses (address reservation with TTL)
  - deposits (pending/confirmed/expired/failed, unique tx_hash)
- Seeding:
  - DepositAddressesSeeder reads STAKING_PI_SEED_ADDRESSES and inserts unique active addresses
- Config:
  - config/deposits.php with defaults (provider=testnet, TTL=15m, confirmations=1, min=10, max=5000, policy_on_rerequest=refuse) and env hooks (DEPOSITS_PROVIDER, DEPOSITS_RESERVATION_TTL, DEPOSITS_CONFIRMATIONS, DEPOSITS_MIN, DEPOSITS_MAX, STAKING_PI_SEED_ADDRESSES, PI_API_URL, PI_API_KEY)
- Models:
  - DepositAddress (relations + scopes free, expiredReservations)
  - Deposit with STATUS_* and relations
- Services:
  - DepositService with assignAddressForUser, releaseExpiredReservations, handleDetectedTransaction, credits Transaction on confirmed
- Watcher (pluggable):
  - Interface PiDepositProviderInterface and providers TestnetProvider (default), SdkProvider (skeleton), ApiProvider (skeleton)
  - DepositWatcherService that queries provider for currently reserved addresses
- Console & schedule:
  - Command pi:scan-deposits and scheduling every minute in Console Kernel
- API:
  - POST /deposit/request and GET /deposit/status/{id} (auth:sanctum), mapped errors (409 for re-request, 429 for no slot)

Acceptance
- Re-request during active reservation returns 409 without reassignment
- Scan confirms deposit on first sufficient confirmation and credits balance; out-of-range amounts mark deposit as failed with no credit
- Expired reservations are freed and reusable

Notes
- Default provider is testnet (mock). SDK/API providers are placeholders until keys/SDK are provided.
- Transactions align with existing schema (status=completed for successful ledger entries)

Deployment steps
1) Run migrations
2) Set STAKING_PI_SEED_ADDRESSES to seed initial pool (or seed later)
3) Ensure scheduler is running for pi:scan-deposits
4) Optionally set DEPOSITS_* env values for your environment

Follow-ups (separate PRs)
- Add feature tests for reservation, expiration, min/max, and confirmation using the testnet provider
- Wire the real SDK/API provider and add integration tests
- Expose deposit request/status on the frontend