### PR TITLE
Bonus de bienvenue: réinvestissement Discovery + alignement claim + UI (compte à rebours)

### DIFF
--- a/pi-staking/apps/backend/app/Http/Controllers/AuthController.php
+++ b/pi-staking/apps/backend/app/Http/Controllers/AuthController.php
@@ -67,6 +67,19 @@ class AuthController extends Controller
     }
 
     /**
+     * Retourner l'utilisateur courant
+     */
+    public function me(Request $request): JsonResponse
+    {
+        $user = $request->user()->load(['activeInvestments', 'bonusGrants']);
+
+        return response()->json([
+            'success' => true,
+            'data' => $user,
+        ]);
+    }
+
+    /**
      * Réinitialisation du mot de passe avec token
      */
     public function resetPassword(Request $request): JsonResponse
@@ -151,35 +164,47 @@ class AuthController extends Controller
     }
 
     /**
-     * Réclamer le bonus de bienvenue (exemple : 50 Pi)
+     * Réclamer le bonus de bienvenue
      */
     public function claimWelcomeBonus(Request $request): JsonResponse
     {
         $user = Auth::user();
 
-        // Vérifier si déjà attribué
-        if (BonusGrant::where('user_id', $user->id)->where('type', 'welcome')->exists()) {
+        $alreadyClaimed = (bool) $user->welcome_bonus_claimed
+            || BonusGrant::where('user_id', $user->id)
+                ->whereIn('type', ['welcome', 'welcome_bonus'])
+                ->exists();
+
+        if ($alreadyClaimed) {
             return response()->json([
                 'success' => false,
                 'message' => 'Bonus de bienvenue déjà réclamé.',
             ], 409);
         }
 
-        // Créer un enregistrement du bonus
+        $amount = (float) config('staking.bonus.discovery_amount', 50);
+        $expiresAt = now()->addDays((int) config('staking.bonus.expiration_days', 90));
+
         BonusGrant::create([
             'user_id' => $user->id,
-            'amount'  => 50, // Bonus fixe de 50 Pi
-            'type'    => 'welcome',
+            'type' => 'welcome',
+            'amount' => $amount,
+            'expires_at' => $expiresAt,
+            'is_used' => false,
+            'description' => 'Bonus de bienvenue',
         ]);
 
-        // Exemple : incrémenter le solde utilisateur
-        $user->increment('balance', 50);
+        $user->increment('bonus_balance', $amount);
+        $user->update(['welcome_bonus_claimed' => true]);
 
         return response()->json([
             'success' => true,
             'message' => 'Bonus de bienvenue réclamé avec succès.',
-            'amount'  => 50,
-            'balance' => $user->balance,
+            'data' => [
+                'amount' => $amount,
+                'bonus_balance' => (float) $user->fresh()->bonus_balance,
+                'user' => $user->fresh(),
+            ],
         ]);
     }
 }

--- a/pi-staking/apps/backend/app/Http/Controllers/StakingController.php
+++ b/pi-staking/apps/backend/app/Http/Controllers/StakingController.php
@@ -9,6 +9,9 @@ use App\Services\UserLevelService;
 use Illuminate\Http\Request;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Validator;
+use Illuminate\Support\Facades\DB;
+use App\Models\BonusGrant;
+use App\Models\Transaction;
 
 class StakingController extends Controller
 {
@@ -94,6 +97,124 @@ class StakingController extends Controller
             return response()->json([
                 'success' => false,
                 'message' => $e->getMessage()
+            ], 422);
+        }
+    }
+
+    /**
+     * Réinvestir le bonus de bienvenue dans le package Discovery
+     */
+    public function reinvestBonus(Request $request): JsonResponse
+    {
+        $user = $request->user();
+
+        if (!$user->welcome_bonus_claimed) {
+            return response()->json([
+                'success' => false,
+                'message' => "Vous n'avez pas encore réclamé votre bonus de bienvenue."
+            ], 422);
+        }
+
+        if ($user->welcome_bonus_reinvested) {
+            return response()->json([
+                'success' => false,
+                'message' => 'Le bonus de bienvenue a déjà été réinvesti.'
+            ], 409);
+        }
+
+        $defaultAmount = (float) config('staking.bonus.discovery_amount', 50);
+        $availableBonus = (float) ($user->bonus_balance ?? 0);
+
+        $grant = BonusGrant::where('user_id', $user->id)
+            ->whereIn('type', ['welcome', 'welcome_bonus'])
+            ->where('is_used', false)
+            ->first();
+
+        $bonusAmount = $grant?->amount ?? ($availableBonus > 0 ? min($availableBonus, $defaultAmount) : $defaultAmount);
+
+        if ($bonusAmount <= 0) {
+            return response()->json([
+                'success' => false,
+                'message' => 'Aucun bonus disponible à réinvestir.'
+            ], 422);
+        }
+
+        // Récupérer ou créer le package Discovery
+        $package = StakingPackage::where('is_discovery_bonus', true)->first();
+        if (!$package) {
+            $package = StakingPackage::create([
+                'name' => 'Discovery',
+                'description' => 'Package de découverte réservé au bonus de bienvenue',
+                'daily_rate' => config('staking.rates.discovery', 0.025),
+                'min_amount' => 0,
+                'max_amount' => null,
+                'duration_days' => config('staking.bonus.discovery_days', 30),
+                'level_requirement' => 'discovery',
+                'is_active' => true,
+                'is_discovery_bonus' => true,
+                'max_concurrent' => 1,
+                'features' => [
+                    'uses_bonus_funds' => true,
+                    'limited_duration' => true,
+                    'one_time_only' => true,
+                ],
+                'sort_order' => -10,
+            ]);
+        }
+
+        try {
+            $investment = DB::transaction(function () use ($user, $package, $bonusAmount, $grant, $availableBonus) {
+                // Créer l'investissement avec source bonus
+                $investment = $this->stakingService->createInvestment($user, $package, $bonusAmount, 'bonus');
+
+                // Débiter le solde bonus utilisateur et marquer le drapeau de réinvestissement
+                $beforeBonus = (float) ($user->bonus_balance ?? 0);
+                if ($beforeBonus > 0) {
+                    $user->decrement('bonus_balance', min($beforeBonus, $bonusAmount));
+                }
+
+                $user->update(['welcome_bonus_reinvested' => true]);
+
+                // Marquer le grant comme utilisé si présent
+                if ($grant) {
+                    $grant->update(['is_used' => true]);
+                }
+
+                // Créer une transaction de traçabilité pour le bonus (source = welcome)
+                Transaction::create([
+                    'user_id' => $user->id,
+                    'type' => 'bonus',
+                    'category' => 'bonus',
+                    'amount' => 0,
+                    'balance_before' => $user->balance_pi,
+                    'balance_after' => $user->balance_pi,
+                    'status' => 'completed',
+                    'investment_id' => $investment->id,
+                    'description' => 'Réinvestissement du bonus de bienvenue dans le package Discovery',
+                    'processed_at' => now(),
+                    'metadata' => [
+                        'source' => 'welcome',
+                        'bonus_before' => $beforeBonus,
+                        'bonus_after' => max(0, $beforeBonus - $bonusAmount),
+                        'reinvested_amount' => $bonusAmount,
+                        'package' => $package->name,
+                    ],
+                ]);
+
+                return $investment;
+            });
+
+            $investment->load('stakingPackage');
+
+            return response()->json([
+                'success' => true,
+                'message' => 'Bonus réinvesti avec succès',
+                'data' => $investment,
+            ], 201);
+        } catch (\Exception $e) {
+            return response()->json([
+                'success' => false,
+                'message' => $e->getMessage(),
             ], 422);
         }
     }

--- a/pi-staking/apps/backend/app/Http/Resources/UserResource.php
+++ b/pi-staking/apps/backend/app/Http/Resources/UserResource.php
@@ -26,6 +26,8 @@ class UserResource extends JsonResource
             'bonus_balance' => (float) $this->bonus_balance,
             'total_invested' => (float) $this->total_invested,
             'total_claimed' => (float) $this->total_claimed,
+            'welcome_bonus_claimed' => (bool) $this->welcome_bonus_claimed,
+            'welcome_bonus_reinvested' => (bool) $this->welcome_bonus_reinvested,
             
             // Level system
             'current_level' => $this->current_level,

--- a/pi-staking/apps/backend/app/Models/BonusGrant.php
+++ b/pi-staking/apps/backend/app/Models/BonusGrant.php
@@ -13,73 +13,36 @@ class BonusGrant extends Model
     protected $fillable = [
         'user_id',
         'type',
-        'original_amount',
-        'remaining_amount',
+        'amount',
         'expires_at',
         'is_used',
+        'description',
         'used_at',
-        'is_expired',
-        'transferable',
-        'withdrawable',
-        'usage_rules',
-        'grant_reason',
-        'metadata',
     ];
 
     protected $casts = [
-        'original_amount' => 'decimal:8',
-        'remaining_amount' => 'decimal:8',
+        'amount' => 'decimal:8',
         'expires_at' => 'datetime',
         'is_used' => 'boolean',
         'used_at' => 'datetime',
-        'is_expired' => 'boolean',
-        'transferable' => 'boolean',
-        'withdrawable' => 'boolean',
-        'usage_rules' => 'array',
-        'metadata' => 'array',
     ];
-
-    // Relations
 
     public function user(): BelongsTo
     {
         return $this->belongsTo(User::class);
     }
 
-    // Scopes
-
     public function scopeAvailable($query)
     {
         return $query->where('is_used', false)
-                    ->where('is_expired', false)
-                    ->where(function ($q) {
-                        $q->whereNull('expires_at')
-                          ->orWhere('expires_at', '>', now());
-                    });
+                      ->where(function ($q) {
+                          $q->whereNull('expires_at')
+                            ->orWhere('expires_at', '>', now());
+                      });
     }
-
-    // Méthodes utilitaires
 
     public function isExpired(): bool
     {
-        return $this->expires_at && $this->expires_at->isPast();
-    }
-
-    public function use(float $amount): bool
-    {
-        if ($this->remaining_amount < $amount) {
-            return false;
-        }
-
-        $this->decrement('remaining_amount', $amount);
-        
-        if ($this->remaining_amount <= 0) {
-            $this->update([
-                'is_used' => true,
-                'used_at' => now(),
-            ]);
-        }
-
-        return true;
+        return $this->expires_at ? $this->expires_at->isPast() : false;
     }
 }

--- a/pi-staking/apps/backend/app/Models/User.php
+++ b/pi-staking/apps/backend/app/Models/User.php
@@ -24,6 +24,7 @@ class User extends Authenticatable implements MustVerifyEmail
         'password',
         'role',
         'balance_pi',
+        'bonus_balance',
         'total_invested',
         'total_earned',
         'total_claimed',
@@ -43,6 +44,8 @@ class User extends Authenticatable implements MustVerifyEmail
         'notification_preferences',
         'timezone',
         'language',
+        'welcome_bonus_claimed',
+        'welcome_bonus_reinvested',
     ];
 
     /**
@@ -66,6 +69,7 @@ class User extends Authenticatable implements MustVerifyEmail
             'last_login_at' => 'datetime',
             'locked_until' => 'datetime',
             'balance_pi' => 'decimal:8',
+            'bonus_balance' => 'decimal:8',
             'total_invested' => 'decimal:8',
             'total_earned' => 'decimal:8',
             'total_claimed' => 'decimal:8',
@@ -76,6 +80,8 @@ class User extends Authenticatable implements MustVerifyEmail
             'failed_login_attempts' => 'integer',
             'loyalty_points' => 'integer',
             'total_referrals' => 'integer',
+            'welcome_bonus_claimed' => 'boolean',
+            'welcome_bonus_reinvested' => 'boolean',
         ];
     }
 
@@ -181,7 +187,7 @@ class User extends Authenticatable implements MustVerifyEmail
         }
         
         if ($source === 'bonus') {
-            return $this->getAvailableBonusAmount() >= $amount;
+            return (float) $this->bonus_balance >= $amount;
         }
         
         return false;
@@ -192,14 +198,7 @@ class User extends Authenticatable implements MustVerifyEmail
      */
     public function getAvailableBonusAmount(): float
     {
-        return $this->bonusGrants()
-            ->where('is_used', false)
-            ->where('is_expired', false)
-            ->where(function ($query) {
-                $query->whereNull('expires_at')
-                    ->orWhere('expires_at', '>', now());
-            })
-            ->sum('remaining_amount');
+        return (float) $this->bonus_balance;
     }
 
     /**

--- a/pi-staking/apps/backend/app/Services/StakingService.php
+++ b/pi-staking/apps/backend/app/Services/StakingService.php
@@ -161,17 +161,39 @@ class StakingService
         float $amount,
         string $source
     ): Transaction {
+        if ($source === 'funds') {
+            return Transaction::create([
+                'user_id' => $user->id,
+                'type' => 'adjustment',
+                'category' => 'staking',
+                'amount' => -$amount,
+                'balance_before' => $user->balance_pi + $amount,
+                'balance_after' => $user->balance_pi,
+                'status' => 'completed',
+                'investment_id' => $investment->id,
+                'description' => 'Staking investment created (funds)',
+                'processed_at' => now(),
+                'metadata' => [
+                    'source' => 'funds',
+                ],
+            ]);
+        }
+
+        // Pour les bonus: ne pas impacter le solde disponible
         return Transaction::create([
             'user_id' => $user->id,
             'type' => 'adjustment',
             'category' => 'staking',
-            'amount' => -$amount,
-            'balance_before' => $user->balance_pi + $amount,
+            'amount' => 0,
+            'balance_before' => $user->balance_pi,
             'balance_after' => $user->balance_pi,
             'status' => 'completed',
             'investment_id' => $investment->id,
-            'description' => 'Staking investment created',
+            'description' => 'Staking investment created (bonus funds)',
             'processed_at' => now(),
+            'metadata' => [
+                'source' => 'bonus',
+            ],
         ]);
     }
 }

--- a/pi-staking/apps/backend/database/migrations/2025_09_10_120200_add_welcome_bonus_flags_to_users.php
+++ b/pi-staking/apps/backend/database/migrations/2025_09_10_120200_add_welcome_bonus_flags_to_users.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            if (!Schema::hasColumn('users', 'welcome_bonus_claimed')) {
+                $table->boolean('welcome_bonus_claimed')->default(false)->after('bonus_balance');
+            }
+            if (!Schema::hasColumn('users', 'welcome_bonus_reinvested')) {
+                $table->boolean('welcome_bonus_reinvested')->default(false)->after('welcome_bonus_claimed');
+            }
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            if (Schema::hasColumn('users', 'welcome_bonus_reinvested')) {
+                $table->dropColumn('welcome_bonus_reinvested');
+            }
+            if (Schema::hasColumn('users', 'welcome_bonus_claimed')) {
+                $table->dropColumn('welcome_bonus_claimed');
+            }
+        });
+    }
+};

--- a/pi-staking/apps/backend/routes/api.php
+++ b/pi-staking/apps/backend/routes/api.php
@@ -64,6 +64,7 @@ Route::middleware('auth:sanctum')->group(function () {
         Route::get('/investment/{id}', [StakingController::class, 'getInvestmentDetails']);
         Route::post('/calculate-earnings', [StakingController::class, 'calculateEarnings']);
         Route::get('/performance', [StakingController::class, 'getPerformanceHistory']);
+        Route::post('/reinvest-bonus', [StakingController::class, 'reinvestBonus']);
     });
 
     // Gestion des réclamations

--- a/pi-staking/pi-staking-frontend/src/components/UserDashboardComplete.tsx
+++ b/pi-staking/pi-staking-frontend/src/components/UserDashboardComplete.tsx
@@ -56,6 +56,7 @@ import { useDashboard } from '../contexts/DashboardContext';
 import { securityService } from '../services/securityService';
 import { transactionsService } from '../services/transactionsService';
 import { claimsService } from '../services/claimsService';
+import { stakingService } from '../services/stakingService';
 
 // Import du composant Parrainage
 import { ReferralDashboard } from './ReferralDashboard';
@@ -66,7 +67,7 @@ interface UserDashboardCompleteProps {
 }
 
 export function UserDashboardComplete({ onLogout }: UserDashboardCompleteProps) {
-  const { state: authState, updateProfile } = useAuth();
+  const { state: authState, updateProfile, refreshUser, claimWelcomeBonus } = useAuth();
   const user = authState.user;
   const { state: stakingState, refreshAllData, createInvestment, claimInvestment } = useStaking();
   const { 
@@ -187,6 +188,34 @@ export function UserDashboardComplete({ onLogout }: UserDashboardCompleteProps) 
     }
   };
 
+  const handleClaimWelcome = async () => {
+    try {
+      const ok = await claimWelcomeBonus();
+      if (ok) {
+        await refreshUser();
+        await refreshAllData();
+        window.alert('Bonus de bienvenue réclamé avec succès');
+      }
+    } catch (e) {
+      console.error(e);
+      window.alert("Échec de la réclamation du bonus");
+    }
+  };
+
+  const handleReinvestBonus = async () => {
+    try {
+      const res = await stakingService.reinvestBonus();
+      if (res.success) {
+        window.alert('Bonus réinvesti avec succès');
+        await refreshAllData();
+        await refreshUser();
+      }
+    } catch (e) {
+      console.error(e);
+      window.alert("Échec du réinvestissement du bonus");
+    }
+  };
+
   const handleClaimAll = async () => {
     if (!claimableInvestments?.length) return;
     
@@ -235,6 +264,52 @@ export function UserDashboardComplete({ onLogout }: UserDashboardCompleteProps) 
   const calculatedTotalInvested = investments?.reduce((sum, inv) => sum + inv.amount, 0) || 0;
   const totalEarnings = investments?.reduce((sum, inv) => sum + (inv.total_earned || 0), 0) || 0;
   const totalClaimable = claimableInvestments?.reduce((sum, inv) => sum + (inv.claimable_amount || 0), 0) || 0;
+
+  const welcomeBonusClaimed = Boolean((user as any)?.welcome_bonus_claimed);
+  const welcomeBonusReinvested = Boolean((user as any)?.welcome_bonus_reinvested);
+  const bonusGrants = (user as any)?.bonus_grants || [];
+  const activeWelcomeGrant = Array.isArray(bonusGrants)
+    ? bonusGrants.find((g: any) => g?.type === 'welcome' && !g?.is_used)
+    : null;
+
+  const [bonusCountdown, setBonusCountdown] = useState<string>('');
+  const [bonusUrgent, setBonusUrgent] = useState<boolean>(false);
+
+  useEffect(() => {
+    if (!activeWelcomeGrant?.expires_at) {
+      setBonusCountdown('');
+      setBonusUrgent(false);
+      return;
+    }
+    const update = () => {
+      const expires = new Date(activeWelcomeGrant.expires_at).getTime();
+      const now = Date.now();
+      let diff = expires - now;
+      if (diff <= 0) {
+        setBonusCountdown('Expiré');
+        setBonusUrgent(true);
+        return;
+      }
+      const d = Math.floor(diff / (1000 * 60 * 60 * 24));
+      diff -= d * 24 * 60 * 60 * 1000;
+      const h = Math.floor(diff / (1000 * 60 * 60));
+      diff -= h * 60 * 60 * 1000;
+      const m = Math.floor(diff / (1000 * 60));
+      diff -= m * 60 * 1000;
+      const s = Math.floor(diff / 1000);
+      const parts = [
+        d > 0 ? `${d}j` : null,
+        `${String(h).padStart(2, '0')}h`,
+        `${String(m).padStart(2, '0')}m`,
+        `${String(s).padStart(2, '0')}s`
+      ].filter(Boolean);
+      setBonusCountdown(parts.join(' '));
+      setBonusUrgent((new Date(activeWelcomeGrant.expires_at).getTime() - now) <= 7 * 24 * 60 * 60 * 1000);
+    };
+    update();
+    const id = setInterval(update, 1000);
+    return () => clearInterval(id);
+  }, [activeWelcomeGrant?.expires_at]);
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-background via-background to-muted/20 relative">
@@ -346,6 +421,21 @@ export function UserDashboardComplete({ onLogout }: UserDashboardCompleteProps) 
 
           {/* Vue d'ensemble */}
           <TabsContent value="overview" className="space-y-6">
+            {/* Bandeau d'incitation pour bonus non réclamé */}
+            {!welcomeBonusClaimed && (
+              <Alert>
+                <Gift className="h-4 w-4" />
+                <AlertDescription className="flex items-center justify-between w-full">
+                  <span>
+                    Vous avez un bonus de bienvenue à réclamer pour découvrir le package "Discovery".
+                  </span>
+                  <Button size="sm" className="ml-4" onClick={handleClaimWelcome}>
+                    Réclamer maintenant
+                  </Button>
+                </AlertDescription>
+              </Alert>
+            )}
+
             {/* Stats Rapides */}
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
               <GlowCard>
@@ -407,6 +497,44 @@ export function UserDashboardComplete({ onLogout }: UserDashboardCompleteProps) 
               </GlowCard>
             </div>
 
+            {/* État du bonus */}
+            {welcomeBonusClaimed && (
+              <GlowCard className={bonusUrgent ? 'ring-1 ring-red-500/40' : ''}>
+                <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+                  <CardTitle className="text-sm font-medium flex items-center gap-2">
+                    <Gift className="h-4 w-4 text-pi-gold" /> Bonus de bienvenue
+                  </CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <div className="grid grid-cols-1 md:grid-cols-4 gap-4 items-center">
+                    <div>
+                      <p className="text-sm text-muted-foreground">Disponible</p>
+                      <p className="text-xl font-bold">
+                        {formatCurrency(Number((user as any)?.bonus_balance ?? 0))} π
+                      </p>
+                    </div>
+                    <div>
+                      <p className="text-sm text-muted-foreground">Expiration</p>
+                      <p className={`text-xl font-bold ${bonusUrgent ? 'text-red-600' : ''}`}>
+                        {activeWelcomeGrant?.expires_at ? formatDate(activeWelcomeGrant.expires_at) : '—'}
+                      </p>
+                    </div>
+                    <div>
+                      <p className="text-sm text-muted-foreground">Compte à rebours</p>
+                      <p className={`text-xl font-bold ${bonusUrgent ? 'text-red-600' : ''}`}>
+                        {bonusCountdown || '—'}
+                      </p>
+                    </div>
+                    <div className="text-right">
+                      <Badge className={bonusUrgent ? 'bg-red-500/10 text-red-600' : ''} variant={welcomeBonusReinvested ? 'default' : 'secondary'}>
+                        {welcomeBonusReinvested ? 'Réinvesti' : 'À réinvestir'}
+                      </Badge>
+                    </div>
+                  </div>
+                </CardContent>
+              </GlowCard>
+            )}
+
             {/* Actions Rapides */}
             <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
               <Button 
@@ -418,6 +546,18 @@ export function UserDashboardComplete({ onLogout }: UserDashboardCompleteProps) 
                   <span>Nouvel Investissement</span>
                 </div>
               </Button>
+
+              {(user as any)?.welcome_bonus_claimed && !(user as any)?.welcome_bonus_reinvested && (
+                <Button 
+                  onClick={handleReinvestBonus}
+                  className="h-16 bg-green-600 hover:bg-green-700 text-white"
+                >
+                  <div className="flex flex-col items-center gap-2">
+                    <Gift className="h-5 w-5" />
+                    <span>Réinvestir mon bonus</span>
+                  </div>
+                </Button>
+              )}
 
               <Button 
                 onClick={handleClaimAll}

--- a/pi-staking/pi-staking-frontend/src/services/stakingService.ts
+++ b/pi-staking/pi-staking-frontend/src/services/stakingService.ts
@@ -144,6 +144,17 @@ class StakingService {
     }
   }
 
+  // Réinvestir le bonus de bienvenue (Discovery)
+  async reinvestBonus(): Promise<{ success: boolean; message: string; data: any }> {
+    try {
+      const response = await api.post('/staking/reinvest-bonus');
+      return response.data;
+    } catch (error) {
+      console.error('Erreur lors du réinvestissement du bonus:', error);
+      throw error;
+    }
+  }
+
   // Calculer les statistiques de staking pour l'utilisateur
   async getStakingStats(): Promise<{
     success: boolean;


### PR DESCRIPTION
# Réinvestissement du bonus de bienvenue — Backend + UI bonus

## Pourquoi
- Harmoniser le flux de bonus de bienvenue (claim → réinvestissement) avec la logique `bonus_balance` et une traçabilité claire.
- Offrir une expérience utilisateur complète côté Dashboard: état du bonus, date d’expiration, compte à rebours et action rapide.
- Mettre des garde-fous anti-abus et limiter l’usage du bonus au package Discovery.

## Changements

### Base de données
- `users`: ajout de deux flags
  - `welcome_bonus_claimed` (bool, défaut: false)
  - `welcome_bonus_reinvested` (bool, défaut: false)

### Backend (Laravel)
- `AuthController`
  - `claimWelcomeBonus` alignée sur `bonus_balance` :
    - Crée un `BonusGrant` de type `welcome` avec `amount = config('staking.bonus.discovery_amount', 50)` et `expires_at` (par défaut 90 jours).
    - Incrémente `bonus_balance`, marque `welcome_bonus_claimed = true`.
  - `me` ajouté: renvoie l’utilisateur courant avec `activeInvestments` et `bonusGrants`.
- `StakingController`
  - Nouvelle méthode `reinvestBonus` (POST `/staking/reinvest-bonus`):
    - Vérifie `welcome_bonus_claimed == true` et `welcome_bonus_reinvested == false`.
    - Garantit l’existence d’un package Discovery (`is_discovery_bonus = true`) et crée l’investissement avec `source = 'bonus'`.
    - Déduit le `bonus_balance`, marque `welcome_bonus_reinvested = true` et set `BonusGrant` comme utilisé si présent.
    - Traçabilité: crée une `Transaction` type `bonus` avec `metadata.source = 'welcome'`.
- `StakingService`
  - Journalisation des transactions d’investissement:
    - Si `source = 'funds'`, débit normal du solde dispo (inchangé).
    - Si `source = 'bonus'`, transaction d’ajustement à `amount = 0` (n’affecte pas `balance_pi`) + `metadata.source = 'bonus'`.
- `User` & `UserResource`
  - Flags exposés dans l’API utilisateur.
- `BonusGrant` (modèle)
  - Simplifié pour coller au schéma utilisé (`amount`, `expires_at`, `is_used`, `description`).

### Frontend (React)
- Service: `stakingService.reinvestBonus()` (POST `/staking/reinvest-bonus`).
- Dashboard (`UserDashboardComplete.tsx`):
  - Bandeau d’incitation si bonus non réclamé avec bouton “Réclamer maintenant” (appelle `claimWelcomeBonus`).
  - Carte “État du bonus” si bonus réclamé: solde bonus disponible, date d’expiration, compte à rebours (JJ:HH:MM:SS) avec style d’alerte < 7 jours, badge “À réinvestir”/“Réinvesti”.
  - Bouton “Réinvestir mon bonus” visible si `welcome_bonus_claimed == true && welcome_bonus_reinvested == false`.

## Impact
- Flux bonus cohérent: claim → bonus_balance/BonusGrant → réinvestissement Discovery.
- Traçabilité renforcée (transactions + metadata).
- UX améliorée: visibilité, urgence avant expiration, actions claires.

## Migrations
- Exécuter dans `apps/backend`: `php artisan migrate`

## QA — Checklist manuelle
1. Auth/Me
   - Appeler `POST /auth/me` authentifié → l’utilisateur contient `bonus_grants` et `active_investments`.
2. Claim du bonus
   - Appeler `POST /auth/claim-welcome-bonus` → succès; `welcome_bonus_claimed = true`, `bonus_balance` augmenté, `BonusGrant` type `welcome` créé avec `expires_at`.
   - Dashboard: bandeau d’incitation disparaît, carte “État du bonus” s’affiche.
3. Compte à rebours & Expiration
   - La carte affiche la date d’expiration + un compte à rebours temps réel.
   - Quand l’expiration est à < 7 jours, style d’alerte (teinte rouge) est visible.
4. Réinvestissement bonus (Discovery)
   - Depuis le Dashboard, cliquer “Réinvestir mon bonus” → `POST /staking/reinvest-bonus`.
   - Vérifier: investissement créé dans le package Discovery avec `source = 'bonus'`; `welcome_bonus_reinvested = true`; le bouton disparaît.
   - Transaction associée créée: `type = bonus`, `metadata.source = 'welcome'`. `balance_pi` inchangé.
5. Double réinvestissement
   - Tenter un second appel → échec (409/422) avec message adéquat.
6. Garde-fous (information)
   - Les fonds bonus ne peuvent pas être utilisés pour d’autres packages (StakingService bloque source bonus hors Discovery).
7. Non-régression
   - Investissement classique avec `funds` demeure fonctionnel et débite `balance_pi`.

## Notes
- Si vous souhaitez interdire explicitement tout retrait/transfert de `bonus_balance`, je peux ajouter les garde-fous côté endpoints de retrait.
- Je peux remplacer les `window.alert` par des toasts non bloquants et ajouter des loaders pour améliorer l’UX.


₍ᐢ•(ܫ)•ᐢ₎ Generated by [Capy](https://capy.ai) ([view task](https://capy.ai/project/5728eb50-84af-11f0-a94e-3eef481a796b/task/e191baf7-5b74-4d75-a519-472c33668f19))