### PR TITLE
Consolidate staking logic: claimables + reinvest + reservations + scheduler + admin export + theme

### DIFF
--- a/pi-staking/apps/backend/app/Console/Kernel.php
+++ b/pi-staking/apps/backend/app/Console/Kernel.php
@@ -9,7 +9,12 @@ class Kernel extends ConsoleKernel
 {
     protected function schedule(Schedule $schedule): void
     {
+        // Scan incoming Pi deposits frequently
         $schedule->command('pi:scan-deposits')->everyMinute();
+
+        // Process daily earnings at 00:05 WAT (UTC+1), timezone configurable via env SCHEDULER_TZ
+        $tz = env('SCHEDULER_TZ', 'Africa/Lagos');
+        $schedule->command('staking:process-daily-earnings')->dailyAt('00:05')->timezone($tz)->withoutOverlapping();
     }
 
     protected function commands(): void

--- a/pi-staking/apps/backend/app/Http/Controllers/AdminController.php
+++ b/pi-staking/apps/backend/app/Http/Controllers/AdminController.php
@@ -26,12 +26,18 @@ class AdminController extends Controller
     public function getDashboardStats(): JsonResponse
     {
         try {
+            // Users overview
+            $totalUsers = User::count();
+            $activeUsers = User::where('last_activity', '>=', now()->subDays(30))->count();
+            $newUsersToday = User::whereDate('created_at', today())->count();
+            $newUsersThisWeek = User::where('created_at', '>=', now()->startOfWeek())->count();
+
             $users = [
-                'total' => User::count(),
+                'total' => $totalUsers,
+                'active' => $activeUsers,
+                'new_today' => $newUsersToday,
+                'new_this_week' => $newUsersThisWeek,
             ];
-            if (Schema::hasColumn('users', 'status')) {
-                $users['active'] = User::where('status', 'active')->count();
-            }
 
             // Métriques financières détaillées
             $totalInvested = Investment::where('status', 'active')->sum('amount');
@@ -67,6 +73,12 @@ class AdminController extends Controller
             }
 
             $packagesCount = StakingPackage::count();
+            $popularPackages = StakingPackage::withCount('investments')
+                ->orderByDesc('investments_count')
+                ->take(5)
+                ->get();
+
+            $activeAlerts = SystemAlert::where('is_resolved', false)->count();
 
             $start = now()->subMonths(12)->startOfMonth();
             $months = [];
@@ -144,7 +156,7 @@ class AdminController extends Controller
                         'new_users_week' => $newUsersThisWeek,
                         'active_users_percentage' => $totalUsers > 0 ? round(($activeUsers / $totalUsers) * 100, 1) : 0,
                         'user_growth_rate' => $this->calculateUserGrowthRate(),
-                            'pending_withdrawals' => WithdrawalRequest::where('status', 'pending')->count(),
+                        'pending_withdrawals' => WithdrawalRequest::where('status', 'pending')->count(),
                     ],
                     'financial' => [
                         'total_value_locked' => $tvl,

--- a/pi-staking/apps/backend/app/Http/Controllers/AdminController.php
+++ b/pi-staking/apps/backend/app/Http/Controllers/AdminController.php
@@ -395,19 +395,20 @@ class AdminController extends Controller
 
         $callback = function () use ($query, $sortBy, $sortDir) {
             $handle = fopen('php://output', 'w');
-            fputcsv($handle, ['ID','Date','Utilisateur','Email','Type','Montant','Statut','Description','Référence']);
+            // English headers, UTC timestamps
+            fputcsv($handle, ['id','user_email','type','status','amount','tx_hash','reference_id','created_at_utc']);
             $query->orderBy($sortBy, $sortDir)->chunk(500, function ($rows) use ($handle) {
                 foreach ($rows as $tx) {
+                    $createdUtc = optional($tx->created_at)?->copy()->setTimezone('UTC')->format('Y-m-d H:i:s');
                     fputcsv($handle, [
                         $tx->id,
-                        optional($tx->created_at)->format('Y-m-d H:i:s'),
-                        optional($tx->user)->username,
                         optional($tx->user)->email,
                         $tx->type,
-                        $tx->amount,
                         $tx->status,
-                        $tx->description,
+                        $tx->amount,
+                        $tx->transaction_hash,
                         $tx->reference_id,
+                        $createdUtc,
                     ]);
                 }
             });

--- a/pi-staking/apps/backend/app/Http/Controllers/AdminWithdrawalController.php
+++ b/pi-staking/apps/backend/app/Http/Controllers/AdminWithdrawalController.php
@@ -88,14 +88,19 @@ class AdminWithdrawalController extends Controller
                 $txn = Transaction::where('withdrawal_request_id', $withdrawal->id)->lockForUpdate()->first();
 
                 if (!$txn) {
-                    $beforeBalance = $user->balance_pi;
-                    if ($beforeBalance < $withdrawal->amount) {
+                    // Cas rare: pas de transaction de réservation
+                    $beforeBalance = (float) $user->balance_pi;
+                    if ($beforeBalance < (float) $withdrawal->amount) {
                         return response()->json([
                             'success' => false,
                             'message' => 'Solde insuffisant pour débiter lors de l\'approbation.'
                         ], 422);
                     }
                     $user->decrement('balance_pi', $withdrawal->amount);
+                    // Réduire la réservation si présente
+                    if ((float) $user->pending_withdrawal >= (float) $withdrawal->amount) {
+                        $user->decrement('pending_withdrawal', $withdrawal->amount);
+                    }
                     $txn = Transaction::create([
                         'user_id' => $user->id,
                         'type' => 'withdrawal',
@@ -107,6 +112,24 @@ class AdminWithdrawalController extends Controller
                         'withdrawal_request_id' => $withdrawal->id,
                         'description' => 'Retrait approuvé manuellement',
                     ]);
+                } else {
+                    // Transaction de réservation existante: convertir en débit et débiter maintenant
+                    $beforeBalance = (float) $user->balance_pi;
+                    if ($beforeBalance < (float) $withdrawal->amount) {
+                        return response()->json([
+                            'success' => false,
+                            'message' => 'Solde insuffisant pour débiter lors de l\'approbation.'
+                        ], 422);
+                    }
+                    $user->decrement('balance_pi', $withdrawal->amount);
+                    // Réduire la réservation
+                    if ((float) $user->pending_withdrawal >= (float) $withdrawal->amount) {
+                        $user->decrement('pending_withdrawal', $withdrawal->amount);
+                    }
+                    $txn->amount = -$withdrawal->amount;
+                    $txn->balance_before = $beforeBalance;
+                    $txn->balance_after = $beforeBalance - (float) $withdrawal->amount;
+                    $txn->description = $txn->description ?: 'Retrait approuvé manuellement';
                 }
 
                 // Mark as approved/completed (no external payout automation here)
@@ -167,13 +190,24 @@ class AdminWithdrawalController extends Controller
             // Refund reserved funds if they were reserved
             $txn = Transaction::where('withdrawal_request_id', $withdrawal->id)->lockForUpdate()->first();
             if ($txn) {
-                // If user was debited at creation, refund now
-                $user->increment('balance_pi', abs((float) $txn->amount));
+                // Si un débit a déjà eu lieu (cas rare), rembourser
+                if ((float) $txn->amount < 0) {
+                    $user->increment('balance_pi', abs((float) $txn->amount));
+                }
+                // Libérer la réservation
+                if ((float) $user->pending_withdrawal >= (float) $withdrawal->amount) {
+                    $user->decrement('pending_withdrawal', $withdrawal->amount);
+                }
                 $txn->status = 'rejected';
                 $txn->processed_at = now();
                 $txn->processed_by = $admin->id;
                 $txn->admin_notes = $validated['reason'];
                 $txn->save();
+            } else {
+                // Pas de transaction trouvée: libérer la réservation si présente
+                if ((float) $user->pending_withdrawal >= (float) $withdrawal->amount) {
+                    $user->decrement('pending_withdrawal', $withdrawal->amount);
+                }
             }
 
             $withdrawal->status = 'rejected';

--- a/pi-staking/apps/backend/app/Http/Controllers/StakingController.php
+++ b/pi-staking/apps/backend/app/Http/Controllers/StakingController.php
@@ -31,7 +31,7 @@ class StakingController extends Controller
         return response()->json([
             'success' => true,
             'data' => [
-                'packages' => $packages->toArray(),
+                'packages' => $packages,
                 'user_level' => $user->current_level,
                 'level_info' => $this->userLevelService->getLevelProgress($user),
             ]

--- a/pi-staking/apps/backend/app/Http/Controllers/StakingController.php
+++ b/pi-staking/apps/backend/app/Http/Controllers/StakingController.php
@@ -102,6 +102,110 @@ class StakingController extends Controller
     }
 
     /**
+     * Réinvestir depuis les soldes claimables
+     */
+    public function reinvest(Request $request): JsonResponse
+    {
+        $validator = Validator::make($request->all(), [
+            'staking_package_id' => 'required|integer|exists:staking_packages,id',
+            'amount' => 'required|numeric|min:0.00000001',
+            'source' => 'required|in:claimable,claimable_bonus',
+        ]);
+
+        if ($validator->fails()) {
+            return response()->json([
+                'success' => false,
+                'message' => 'Erreurs de validation',
+                'errors' => $validator->errors(),
+            ], 422);
+        }
+
+        $user = $request->user();
+        $package = StakingPackage::findOrFail($request->staking_package_id);
+        $amount = (float) $request->amount;
+        $source = $request->source;
+
+        try {
+            $result = DB::transaction(function () use ($user, $package, $amount, $source) {
+                if ($source === 'claimable_bonus') {
+                    if (!$package->is_discovery_bonus) {
+                        throw new \Exception('Les gains bonus ne peuvent être réinvestis que dans Discovery.');
+                    }
+                    if ((float) $user->claimable_bonus_balance < $amount) {
+                        throw new \Exception('Solde de gains bonus insuffisant.');
+                    }
+
+                    // Chercher un investissement bonus actif (unique autorisé)
+                    $existing = Investment::where('user_id', $user->id)
+                        ->where('source', 'bonus')
+                        ->where('status', 'active')
+                        ->first();
+
+                    if ($existing) {
+                        // Compound sur le même investissement (respecter min/max)
+                        $newAmount = (float) $existing->amount + $amount;
+                        if ($package->max_amount && $newAmount > (float) $package->max_amount) {
+                            throw new \Exception('Le montant total dépasserait le maximum autorisé pour ce package.');
+                        }
+                        if ($newAmount < (float) $package->min_amount) {
+                            throw new \Exception('Le montant total serait inférieur au minimum requis.');
+                        }
+
+                        $before = (float) $existing->amount;
+                        $existing->update(['amount' => $newAmount]);
+                        $user->decrement('claimable_bonus_balance', $amount);
+
+                        Transaction::create([
+                            'user_id' => $user->id,
+                            'type' => 'adjustment',
+                            'category' => 'staking',
+                            'amount' => 0,
+                            'balance_before' => $user->balance_pi,
+                            'balance_after' => $user->balance_pi,
+                            'status' => 'completed',
+                            'investment_id' => $existing->id,
+                            'description' => 'Compound (claimable bonus) into Discovery investment',
+                            'processed_at' => now(),
+                            'metadata' => [
+                                'source' => 'claimable_bonus',
+                                'investment_amount_before' => $before,
+                                'investment_amount_after' => $newAmount,
+                                'claimable_bonus_before' => $user->claimable_bonus_balance + $amount,
+                                'claimable_bonus_after' => $user->claimable_bonus_balance,
+                            ],
+                        ]);
+
+                        return $existing->fresh('stakingPackage');
+                    }
+
+                    // Aucun investissement bonus existant: créer le premier
+                    $investment = $this->stakingService->createInvestment($user, $package, $amount, 'claimable_bonus');
+                    return $investment->load('stakingPackage');
+                }
+
+                // Source = claimable (fonds réels)
+                if ((float) $user->claimable_balance < $amount) {
+                    throw new \Exception('Solde de gains claimables insuffisant.');
+                }
+
+                $investment = $this->stakingService->createInvestment($user, $package, $amount, 'claimable');
+                return $investment->load('stakingPackage');
+            });
+
+            return response()->json([
+                'success' => true,
+                'message' => 'Réinvestissement effectué avec succès',
+                'data' => $result,
+            ], 201);
+        } catch (\Throwable $e) {
+            return response()->json([
+                'success' => false,
+                'message' => $e->getMessage(),
+            ], 422);
+        }
+    }
+
+    /**
      * Réinvestir le bonus de bienvenue dans le package Discovery
      */
     public function reinvestBonus(Request $request): JsonResponse

--- a/pi-staking/apps/backend/app/Http/Controllers/TransactionController.php
+++ b/pi-staking/apps/backend/app/Http/Controllers/TransactionController.php
@@ -38,11 +38,12 @@ class TransactionController extends Controller
         $user = $request->user();
         $amount = $request->amount;
 
-        // Vérifications de sécurité
-        if ($user->balance_pi < $amount) {
+        // Vérifications de sécurité: disponibilité = balance - pending_withdrawal
+        $available = (float) $user->balance_pi - (float) $user->pending_withdrawal;
+        if ($available < $amount) {
             return response()->json([
                 'success' => false,
-                'message' => 'Solde insuffisant pour effectuer ce retrait.'
+                'message' => 'Solde disponible insuffisant (fonds réservés pour d\'autres retraits).'
             ], 422);
         }
 
@@ -84,8 +85,9 @@ class TransactionController extends Controller
 
         try {
             DB::transaction(function () use ($user, $amount, $request, &$withdrawalRequest) {
-                // Bloquer les fonds immédiatement
-                $user->decrement('balance_pi', $amount);
+                // Réserver les fonds
+                $beforePending = (float) $user->pending_withdrawal;
+                $user->increment('pending_withdrawal', $amount);
                 
                 // Créer la demande de retrait
                 $withdrawalRequest = WithdrawalRequest::create([
@@ -97,17 +99,22 @@ class TransactionController extends Controller
                     'requested_at' => now(),
                 ]);
 
-                // Créer la transaction
+                // Créer la transaction de réservation (montant 0, statut pending)
                 Transaction::create([
                     'user_id' => $user->id,
                     'type' => 'withdrawal',
                     'category' => 'withdrawal',
-                    'amount' => -$amount,
-                    'balance_before' => $user->balance_pi + $amount,
+                    'amount' => 0,
+                    'balance_before' => $user->balance_pi,
                     'balance_after' => $user->balance_pi,
                     'status' => 'pending',
                     'withdrawal_request_id' => $withdrawalRequest->id,
-                    'description' => 'Demande de retrait - ' . $amount . ' Pi',
+                    'description' => 'Demande de retrait (réservation) - ' . $amount . ' Pi',
+                    'metadata' => [
+                        'reserved_amount' => $amount,
+                        'pending_before' => $beforePending,
+                        'pending_after' => $beforePending + $amount,
+                    ],
                 ]);
             });
 
@@ -259,8 +266,8 @@ class TransactionController extends Controller
 
         try {
             DB::transaction(function () use ($withdrawal, $user) {
-                // Rembourser les fonds
-                $user->increment('balance_pi', $withdrawal->amount);
+                // Libérer la réservation
+                $user->decrement('pending_withdrawal', $withdrawal->amount);
                 
                 // Marquer comme annulée
                 $withdrawal->update([
@@ -302,7 +309,7 @@ class TransactionController extends Controller
         
         $stats = [
             'balances' => [
-                'available_balance' => $user->balance_pi,
+                'available_balance' => (float) $user->balance_pi - (float) $user->pending_withdrawal,
                 'bonus_balance' => $user->bonus_balance,
                 'staked_amount' => $user->activeInvestments->sum('amount'),
                 'total_claimed' => $user->total_claimed,
@@ -321,9 +328,7 @@ class TransactionController extends Controller
                     ->where('status', 'approved')
                     ->where('processed_at', '>=', now()->startOfMonth())
                     ->sum('amount'),
-                'pending_withdrawals' => $user->withdrawalRequests()
-                    ->where('status', 'pending')
-                    ->sum('amount'),
+                'pending_withdrawals' => (float) $user->pending_withdrawal,
             ],
             'kyc' => [
                 'status' => $user->kyc_status,

--- a/pi-staking/apps/backend/app/Models/User.php
+++ b/pi-staking/apps/backend/app/Models/User.php
@@ -29,6 +29,9 @@ class User extends Authenticatable implements MustVerifyEmail
         'total_earned',
         'total_claimed',
         'total_withdrawn',
+        'claimable_balance',
+        'claimable_bonus_balance',
+        'pending_withdrawal',
         'current_level',
         'level_updated_at',
         'referral_code',
@@ -74,6 +77,9 @@ class User extends Authenticatable implements MustVerifyEmail
             'total_earned' => 'decimal:8',
             'total_claimed' => 'decimal:8',
             'total_withdrawn' => 'decimal:8',
+            'claimable_balance' => 'decimal:8',
+            'claimable_bonus_balance' => 'decimal:8',
+            'pending_withdrawal' => 'decimal:8',
             'referral_earnings' => 'decimal:8',
             'streak_bonus' => 'decimal:4',
             'notification_preferences' => 'array',
@@ -183,11 +189,20 @@ class User extends Authenticatable implements MustVerifyEmail
     public function canInvest(float $amount, string $source = 'funds'): bool
     {
         if ($source === 'funds') {
-            return $this->balance_pi >= $amount;
+            $available = (float) $this->balance_pi - (float) $this->pending_withdrawal;
+            return $available >= $amount;
         }
-        
+
         if ($source === 'bonus') {
             return (float) $this->bonus_balance >= $amount;
+        }
+
+        if ($source === 'claimable') {
+            return (float) $this->claimable_balance >= $amount;
+        }
+
+        if ($source === 'claimable_bonus') {
+            return (float) $this->claimable_bonus_balance >= $amount;
         }
         
         return false;

--- a/pi-staking/apps/backend/app/Services/ClaimService.php
+++ b/pi-staking/apps/backend/app/Services/ClaimService.php
@@ -26,8 +26,12 @@ class ClaimService
             // Créer le claim
             $claim = $this->createClaimRecord($user, $investment, $amount);
 
-            // Créditer le solde utilisateur
-            $user->increment('balance_pi', $amount);
+            // Créditer les soldes claimables (pas le solde disponible)
+            if ($investment->source === 'bonus') {
+                $user->increment('claimable_bonus_balance', $amount);
+            } else {
+                $user->increment('claimable_balance', $amount);
+            }
             $user->increment('total_claimed', $amount);
             if (\Illuminate\Support\Facades\Schema::hasColumn('users', 'total_earned')) {
                 $user->increment('total_earned', $amount);
@@ -133,14 +137,18 @@ class ClaimService
             'user_id' => $user->id,
             'type' => 'claim',
             'category' => 'staking',
-            'amount' => $amount,
-            'balance_before' => $user->balance_pi - $amount,
+            'amount' => 0,
+            'balance_before' => $user->balance_pi,
             'balance_after' => $user->balance_pi,
             'status' => 'completed',
             'investment_id' => $claim->investment_id,
             'claim_id' => $claim->id,
-            'description' => 'Claim quotidien - ' . $claim->investment->stakingPackage->name,
+            'description' => 'Daily claim credited to claimable balance',
             'processed_at' => now(),
+            'metadata' => [
+                'credited_to' => $claim->investment->source === 'bonus' ? 'claimable_bonus' : 'claimable',
+                'amount' => $amount,
+            ],
         ]);
     }
 

--- a/pi-staking/apps/backend/app/Services/StakingService.php
+++ b/pi-staking/apps/backend/app/Services/StakingService.php
@@ -25,7 +25,7 @@ class StakingService
         User $user,
         StakingPackage $package,
         float $amount,
-        string $source = 'funds'
+        string $source = 'funds' // funds|bonus|claimable|claimable_bonus
     ): Investment {
         return DB::transaction(function () use ($user, $package, $amount, $source) {
             // Validations
@@ -34,8 +34,11 @@ class StakingService
             // Débiter les fonds selon la source
             $this->debitFunds($user, $amount, $source);
 
+            // Mapper la source d'origine pour l'investissement
+            $origin = in_array($source, ['funds', 'claimable'], true) ? 'funds' : 'bonus';
+
             // Créer l'investissement
-            $investment = $this->createInvestmentRecord($user, $package, $amount, $source);
+            $investment = $this->createInvestmentRecord($user, $package, $amount, $origin);
 
             // Créer la transaction
             $this->createInvestmentTransaction($user, $investment, $amount, $source);
@@ -82,15 +85,12 @@ class StakingService
         }
 
         // Règles spécifiques bonus Discovery
-        if ($package->is_discovery_bonus && $source !== 'bonus') {
-            throw new Exception('Ce package ne peut être utilisé qu\'avec des fonds bonus.');
+        if (in_array($source, ['bonus', 'claimable_bonus'], true) && !$package->is_discovery_bonus) {
+            throw new Exception('Les fonds bonus et leurs gains ne peuvent être utilisés que pour le package Découverte.');
         }
 
         if ($source === 'bonus') {
-            if (!$package->is_discovery_bonus) {
-                throw new Exception('Les fonds bonus ne peuvent être utilisés que pour le package Découverte.');
-            }
-            // Anti-abus: un seul investissement via bonus par utilisateur
+            // Anti-abus: un seul investissement créé directement depuis bonus par utilisateur
             $hasBonusInvestment = Investment::where('user_id', $user->id)
                 ->where('source', 'bonus')
                 ->exists();
@@ -146,6 +146,15 @@ class StakingService
         }
         if ($source === 'bonus') {
             $user->decrement('bonus_balance', $amount);
+            return;
+        }
+        if ($source === 'claimable') {
+            $user->decrement('claimable_balance', $amount);
+            return;
+        }
+        if ($source === 'claimable_bonus') {
+            $user->decrement('claimable_bonus_balance', $amount);
+            return;
         }
     }
 
@@ -153,7 +162,7 @@ class StakingService
         User $user,
         StakingPackage $package,
         float $amount,
-        string $source
+        string $origin
     ): Investment {
         $startAt = now();
         $endAt = $package->duration_days ? $startAt->clone()->addDays($package->duration_days) : null;
@@ -166,7 +175,7 @@ class StakingService
             'start_at' => $startAt,
             'end_at' => $endAt,
             'status' => 'active',
-            'source' => $source,
+            'source' => $origin,
             'next_claim_at' => $startAt->clone()->addDay(),
             'bonus_multiplier' => 1.0,
         ]);
@@ -196,7 +205,27 @@ class StakingService
             ]);
         }
 
-        // Pour les bonus: ne pas impacter le solde disponible
+        if ($source === 'claimable') {
+            return Transaction::create([
+                'user_id' => $user->id,
+                'type' => 'adjustment',
+                'category' => 'staking',
+                'amount' => 0,
+                'balance_before' => $user->balance_pi,
+                'balance_after' => $user->balance_pi,
+                'status' => 'completed',
+                'investment_id' => $investment->id,
+                'description' => 'Reinvest from claimable balance',
+                'processed_at' => now(),
+                'metadata' => [
+                    'source' => 'claimable',
+                    'claimable_before' => (float) $user->claimable_balance + $amount,
+                    'claimable_after' => (float) $user->claimable_balance,
+                ],
+            ]);
+        }
+
+        // Pour les bonus et bonus claimable: ne pas impacter le solde disponible
         return Transaction::create([
             'user_id' => $user->id,
             'type' => 'adjustment',
@@ -206,10 +235,12 @@ class StakingService
             'balance_after' => $user->balance_pi,
             'status' => 'completed',
             'investment_id' => $investment->id,
-            'description' => 'Staking investment created (bonus funds)',
+            'description' => $source === 'claimable_bonus' ? 'Reinvest from claimable bonus' : 'Staking investment created (bonus funds)',
             'processed_at' => now(),
             'metadata' => [
-                'source' => 'bonus',
+                'source' => $source === 'claimable_bonus' ? 'claimable_bonus' : 'bonus',
+                'claimable_bonus_before' => $source === 'claimable_bonus' ? ((float) $user->claimable_bonus_balance + $amount) : null,
+                'claimable_bonus_after' => $source === 'claimable_bonus' ? (float) $user->claimable_bonus_balance : null,
             ],
         ]);
     }

--- a/pi-staking/apps/backend/app/Services/StakingService.php
+++ b/pi-staking/apps/backend/app/Services/StakingService.php
@@ -65,33 +65,46 @@ class StakingService
         float $amount,
         string $source
     ): void {
-        // Vérifier que le package est actif
         if (!$package->is_active) {
             throw new Exception('Ce package de staking n\'est plus disponible.');
         }
 
-        // Vérifier que l'utilisateur peut utiliser ce package
         if (!$package->canBeUsedBy($user)) {
             throw new Exception('Vous ne remplissez pas les conditions pour ce package.');
         }
 
-        // Vérifier que le montant est valide
         if (!$package->isValidAmount($amount)) {
             throw new Exception('Le montant doit être entre ' . $package->min_amount . ' et ' . ($package->max_amount ?? 'illimité') . ' Pi.');
         }
 
-        // Vérifier que l'utilisateur a les fonds suffisants
         if (!$user->canInvest($amount, $source)) {
             throw new Exception('Fonds insuffisants pour cet investissement.');
         }
 
-        // Vérifications spécifiques pour le bonus de découverte
+        // Règles spécifiques bonus Discovery
         if ($package->is_discovery_bonus && $source !== 'bonus') {
             throw new Exception('Ce package ne peut être utilisé qu\'avec des fonds bonus.');
         }
 
-        if ($source === 'bonus' && !$package->is_discovery_bonus) {
-            throw new Exception('Les fonds bonus ne peuvent être utilisés que pour le package Découverte.');
+        if ($source === 'bonus') {
+            if (!$package->is_discovery_bonus) {
+                throw new Exception('Les fonds bonus ne peuvent être utilisés que pour le package Découverte.');
+            }
+            // Anti-abus: un seul investissement via bonus par utilisateur
+            $hasBonusInvestment = Investment::where('user_id', $user->id)
+                ->where('source', 'bonus')
+                ->exists();
+            if ($hasBonusInvestment) {
+                throw new Exception('Vous avez déjà utilisé votre bonus de bienvenue pour un investissement.');
+            }
+            // Expiration du bonus: refuser si tous les bonus sont expirés
+            $activeGrant = \App\Models\BonusGrant::where('user_id', $user->id)
+                ->whereIn('type', ['welcome', 'welcome_bonus'])
+                ->available()
+                ->first();
+            if (!$activeGrant) {
+                throw new Exception('Votre bonus de bienvenue n\'est pas disponible ou a expiré.');
+            }
         }
     }
 
@@ -129,6 +142,10 @@ class StakingService
     {
         if ($source === 'funds') {
             $user->decrement('balance_pi', $amount);
+            return;
+        }
+        if ($source === 'bonus') {
+            $user->decrement('bonus_balance', $amount);
         }
     }
 

--- a/pi-staking/apps/backend/database/migrations/2025_09_15_120000_add_claimable_and_pending_to_users.php
+++ b/pi-staking/apps/backend/database/migrations/2025_09_15_120000_add_claimable_and_pending_to_users.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            if (!Schema::hasColumn('users', 'claimable_balance')) {
+                $table->decimal('claimable_balance', 16, 8)->default(0)->after('bonus_balance');
+            }
+            if (!Schema::hasColumn('users', 'claimable_bonus_balance')) {
+                $table->decimal('claimable_bonus_balance', 16, 8)->default(0)->after('claimable_balance');
+            }
+            if (!Schema::hasColumn('users', 'pending_withdrawal')) {
+                $table->decimal('pending_withdrawal', 16, 8)->default(0)->after('total_withdrawn');
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            if (Schema::hasColumn('users', 'claimable_balance')) {
+                $table->dropColumn('claimable_balance');
+            }
+            if (Schema::hasColumn('users', 'claimable_bonus_balance')) {
+                $table->dropColumn('claimable_bonus_balance');
+            }
+            if (Schema::hasColumn('users', 'pending_withdrawal')) {
+                $table->dropColumn('pending_withdrawal');
+            }
+        });
+    }
+};

--- a/pi-staking/apps/backend/routes/api.php
+++ b/pi-staking/apps/backend/routes/api.php
@@ -66,6 +66,7 @@ Route::middleware('auth:sanctum')->group(function () {
         Route::post('/calculate-earnings', [StakingController::class, 'calculatePotentialEarnings']);
         Route::get('/performance', [StakingController::class, 'getPerformanceHistory']);
         Route::post('/reinvest-bonus', [StakingController::class, 'reinvestBonus']);
+        Route::post('/reinvest', [StakingController::class, 'reinvest']);
     });
 
     // Gestion des réclamations

--- a/pi-staking/apps/backend/tests/Feature/AdminTransactionsExportTest.php
+++ b/pi-staking/apps/backend/tests/Feature/AdminTransactionsExportTest.php
@@ -36,6 +36,6 @@ class AdminTransactionsExportTest extends TestCase
 
         $response->assertOk();
         $response->assertHeader('Content-Type', 'text/csv');
-        $this->assertStringContainsString('ID,Date,Utilisateur,Email,Type,Montant,Statut,Description,Référence', $response->streamedContent());
+        $this->assertStringContainsString('id,user_email,type,status,amount,tx_hash,reference_id,created_at_utc', $response->streamedContent());
     }
 }

--- a/pi-staking/apps/backend/tests/Feature/AdminWithdrawalsTest.php
+++ b/pi-staking/apps/backend/tests/Feature/AdminWithdrawalsTest.php
@@ -24,24 +24,25 @@ class AdminWithdrawalsTest extends TestCase
         $admin = User::factory()->create(['email' => 'admin@example.com']);
         $admin->assignRole('admin');
 
-        $user = User::factory()->create(['balance_pi' => 100.00]);
+        $user = User::factory()->create(['balance_pi' => 100.00, 'pending_withdrawal' => 0]);
         $withdrawal = WithdrawalRequest::create([
             'user_id' => $user->id,
             'amount' => 50.00,
             'status' => 'pending',
         ]);
 
-        $beforeBalance = $user->balance_pi;
-        $user->decrement('balance_pi', 50.00);
+        $beforeBalance = (float) $user->balance_pi;
+        $user->increment('pending_withdrawal', 50.00);
         $txn = Transaction::create([
             'user_id' => $user->id,
             'type' => 'withdrawal',
             'category' => 'withdrawal',
-            'amount' => -50.00,
+            'amount' => 0,
             'balance_before' => $beforeBalance,
-            'balance_after' => $beforeBalance - 50.00,
+            'balance_after' => $beforeBalance,
             'status' => 'pending',
             'withdrawal_request_id' => $withdrawal->id,
+            'description' => 'Demande de retrait (réservation)',
         ]);
 
         $response = $this->actingAs($admin, 'sanctum')
@@ -50,9 +51,13 @@ class AdminWithdrawalsTest extends TestCase
             ]);
 
         $response->assertOk();
+        $freshUser = $user->fresh();
+        $freshTxn = $txn->fresh();
         $this->assertEquals('approved', $withdrawal->fresh()->status);
-        $this->assertEquals('completed', $txn->fresh()->status);
-        $this->assertEquals($beforeBalance - 50.00, (float)$user->fresh()->balance_pi);
+        $this->assertEquals('completed', $freshTxn->status);
+        $this->assertEquals(-50.00, (float) $freshTxn->amount);
+        $this->assertEquals($beforeBalance - 50.00, (float)$freshUser->balance_pi);
+        $this->assertEquals(0.0, (float)$freshUser->pending_withdrawal);
     }
 
     public function test_admin_can_reject_withdrawal_and_refund(): void
@@ -60,24 +65,25 @@ class AdminWithdrawalsTest extends TestCase
         $admin = User::factory()->create(['email' => 'admin2@example.com']);
         $admin->assignRole('admin');
 
-        $user = User::factory()->create(['balance_pi' => 80.00]);
+        $user = User::factory()->create(['balance_pi' => 80.00, 'pending_withdrawal' => 0]);
         $withdrawal = WithdrawalRequest::create([
             'user_id' => $user->id,
             'amount' => 30.00,
             'status' => 'pending',
         ]);
 
-        $beforeBalance = $user->balance_pi;
-        $user->decrement('balance_pi', 30.00);
+        $beforeBalance = (float) $user->balance_pi;
+        $user->increment('pending_withdrawal', 30.00);
         $txn = Transaction::create([
             'user_id' => $user->id,
             'type' => 'withdrawal',
             'category' => 'withdrawal',
-            'amount' => -30.00,
+            'amount' => 0,
             'balance_before' => $beforeBalance,
-            'balance_after' => $beforeBalance - 30.00,
+            'balance_after' => $beforeBalance,
             'status' => 'pending',
             'withdrawal_request_id' => $withdrawal->id,
+            'description' => 'Demande de retrait (réservation)',
         ]);
 
         $response = $this->actingAs($admin, 'sanctum')
@@ -87,8 +93,11 @@ class AdminWithdrawalsTest extends TestCase
             ]);
 
         $response->assertOk();
+        $freshUser = $user->fresh();
+        $freshTxn = $txn->fresh();
         $this->assertEquals('rejected', $withdrawal->fresh()->status);
-        $this->assertEquals('rejected', $txn->fresh()->status);
-        $this->assertEquals($beforeBalance, (float)$user->fresh()->balance_pi);
+        $this->assertEquals('rejected', $freshTxn->status);
+        $this->assertEquals(0.0, (float)$freshUser->pending_withdrawal);
+        $this->assertEquals($beforeBalance, (float)$freshUser->balance_pi);
     }
 }

--- a/pi-staking/apps/backend/tests/Feature/E2EStakingFlowTest.php
+++ b/pi-staking/apps/backend/tests/Feature/E2EStakingFlowTest.php
@@ -1,0 +1,279 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use App\Models\DepositAddress;
+use App\Models\WithdrawalRequest;
+use App\Models\Investment;
+use App\Models\StakingPackage;
+use App\Models\Transaction;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Spatie\Permission\Models\Role;
+use Tests\TestCase;
+
+class E2EStakingFlowTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Role::findOrCreate('admin');
+    }
+
+    public function test_funds_flow_end_to_end(): void
+    {
+        $admin = User::factory()->create(['email' => 'admin@example.com']);
+        $admin->assignRole('admin');
+
+        $user = User::factory()->create([
+            'balance_pi' => 0,
+            'bonus_balance' => 0,
+            'claimable_balance' => 0,
+            'claimable_bonus_balance' => 0,
+            'pending_withdrawal' => 0,
+        ]);
+
+        // Packages
+        $bronze = StakingPackage::create([
+            'name' => 'Bronze',
+            'description' => 'Standard funds package',
+            'daily_rate' => 0.01,
+            'min_amount' => 10,
+            'max_amount' => 100000,
+            'duration_days' => 30,
+            'max_duration_days' => 30,
+            'level' => 'bronze',
+            'is_active' => true,
+            'is_discovery_bonus' => false,
+            'max_concurrent' => 5,
+            'features' => [],
+            'sort_order' => 1,
+        ]);
+
+        // Provision a deposit address
+        $addr = DepositAddress::create([
+            'address' => 'TST_ADDR_1',
+            'is_active' => true,
+        ]);
+
+        // User requests a deposit address
+        $res = $this->actingAs($user, 'sanctum')
+            ->postJson('/api/deposit/request');
+        $res->assertOk();
+        $depositId = $res->json('data.id');
+
+        // Admin confirms deposit (credits balance)
+        $confirm = $this->actingAs($admin, 'sanctum')
+            ->postJson("/api/admin/deposits/{$depositId}/confirm", [
+                'amount' => 100,
+                'tx_hash' => 'tx_funds_flow_'.uniqid(),
+            ]);
+        $confirm->assertOk();
+        $this->assertEquals(100.0, (float) $user->fresh()->balance_pi);
+
+        // Stake 50 from funds
+        $stake = $this->actingAs($user, 'sanctum')
+            ->postJson('/api/staking/invest', [
+                'staking_package_id' => $bronze->id,
+                'amount' => 50,
+                'source' => 'funds',
+            ]);
+        $stake->assertCreated();
+        /** @var Investment $investment */
+        $investment = Investment::latest('id')->first();
+        $this->assertNotNull($investment);
+        $this->assertEquals('funds', $investment->source);
+        $this->assertEquals(50.0, (float) $investment->amount);
+        $this->assertEquals(50.0, (float) $user->fresh()->balance_pi);
+
+        // Make claim available now and run daily earnings (idempotent)
+        $investment->update([
+            'start_at' => now()->subDay(),
+            'next_claim_at' => now()->subMinute(),
+        ]);
+
+        \Artisan::call('staking:process-daily-earnings');
+        $user->refresh();
+        $this->assertEquals(0.5, (float) $user->claimable_balance);
+        $this->assertEquals(0.0, (float) $user->claimable_bonus_balance);
+
+        // Re-run (idempotence)
+        \Artisan::call('staking:process-daily-earnings');
+        $this->assertEquals(0.5, (float) $user->fresh()->claimable_balance);
+
+        // Reinvest from claimable into Bronze
+        $reinvest = $this->actingAs($user, 'sanctum')
+            ->postJson('/api/staking/reinvest', [
+                'staking_package_id' => $bronze->id,
+                'amount' => 0.5,
+                'source' => 'claimable',
+            ]);
+        $reinvest->assertCreated();
+        $user->refresh();
+        $this->assertEquals(0.0, (float) $user->claimable_balance);
+
+        // Create a withdrawal request by reserving funds (simulate request API)
+        $this->assertEquals(50.0, (float) $user->balance_pi);
+        $amountW = 10.0;
+        $beforePending = (float) $user->pending_withdrawal;
+        $user->increment('pending_withdrawal', $amountW);
+        $wr = WithdrawalRequest::create([
+            'user_id' => $user->id,
+            'amount' => $amountW,
+            'status' => 'pending',
+        ]);
+        Transaction::create([
+            'user_id' => $user->id,
+            'type' => 'withdrawal',
+            'category' => 'withdrawal',
+            'amount' => 0,
+            'balance_before' => $user->balance_pi,
+            'balance_after' => $user->balance_pi,
+            'status' => 'pending',
+            'withdrawal_request_id' => $wr->id,
+            'description' => 'Demande de retrait (réservation)',
+            'metadata' => [
+                'reserved_amount' => $amountW,
+                'pending_before' => $beforePending,
+                'pending_after' => $beforePending + $amountW,
+            ],
+        ]);
+
+        // Admin approves -> debit definitive
+        $approve = $this->actingAs($admin, 'sanctum')
+            ->patchJson("/api/admin/withdrawals/{$wr->id}", [
+                'action' => 'approve',
+            ]);
+        $approve->assertOk();
+        $user->refresh();
+        $this->assertEquals(40.0, (float) $user->balance_pi);
+        $this->assertEquals(0.0, (float) $user->pending_withdrawal);
+
+        // New reservation then reject -> funds unlocked
+        $user->increment('pending_withdrawal', 5.0);
+        $wr2 = WithdrawalRequest::create([
+            'user_id' => $user->id,
+            'amount' => 5.0,
+            'status' => 'pending',
+        ]);
+        Transaction::create([
+            'user_id' => $user->id,
+            'type' => 'withdrawal',
+            'category' => 'withdrawal',
+            'amount' => 0,
+            'balance_before' => $user->balance_pi,
+            'balance_after' => $user->balance_pi,
+            'status' => 'pending',
+            'withdrawal_request_id' => $wr2->id,
+        ]);
+        $reject = $this->actingAs($admin, 'sanctum')
+            ->patchJson("/api/admin/withdrawals/{$wr2->id}", [
+                'action' => 'reject',
+                'reason' => 'manual_test',
+            ]);
+        $reject->assertOk();
+        $user->refresh();
+        $this->assertEquals(40.0, (float) $user->balance_pi);
+        $this->assertEquals(0.0, (float) $user->pending_withdrawal);
+    }
+
+    public function test_bonus_flow_end_to_end(): void
+    {
+        $admin = User::factory()->create(['email' => 'admin2@example.com']);
+        $admin->assignRole('admin');
+
+        $user = User::factory()->create([
+            'balance_pi' => 0,
+            'bonus_balance' => 0,
+            'claimable_balance' => 0,
+            'claimable_bonus_balance' => 0,
+            'pending_withdrawal' => 0,
+            'welcome_bonus_claimed' => false,
+            'welcome_bonus_reinvested' => false,
+        ]);
+
+        // Discovery package
+        $discovery = StakingPackage::create([
+            'name' => 'Discovery',
+            'description' => 'Discovery-only (bonus)',
+            'daily_rate' => 0.025,
+            'min_amount' => 0,
+            'max_amount' => 100000,
+            'duration_days' => 30,
+            'max_duration_days' => 30,
+            'level' => 'discovery',
+            'is_active' => true,
+            'is_discovery_bonus' => true,
+            'max_concurrent' => 1,
+            'features' => ['uses_bonus_funds' => true],
+            'sort_order' => -10,
+        ]);
+
+        // Claim welcome bonus
+        $claimBonus = $this->actingAs($user, 'sanctum')
+            ->postJson('/api/auth/claim-welcome-bonus');
+        $claimBonus->assertOk();
+        $this->assertEquals(50.0, (float) $user->fresh()->bonus_balance);
+
+        // Stake discovery using bonus
+        $stake = $this->actingAs($user, 'sanctum')
+            ->postJson('/api/staking/invest', [
+                'staking_package_id' => $discovery->id,
+                'amount' => 50,
+                'source' => 'bonus',
+            ]);
+        $stake->assertCreated();
+        $investment = Investment::latest('id')->first();
+        $this->assertEquals('bonus', $investment->source);
+        $this->assertEquals(0.0, (float) $user->fresh()->bonus_balance);
+
+        // Make claim available and process scheduler
+        $investment->update([
+            'start_at' => now()->subDay(),
+            'next_claim_at' => now()->subMinute(),
+        ]);
+        \Artisan::call('staking:process-daily-earnings');
+        $user->refresh();
+        $expected = round(50 * 0.025, 8);
+        $this->assertEquals($expected, (float) $user->claimable_bonus_balance);
+
+        // Reinvest from claimable_bonus -> compound into existing bonus investment
+        $rein = $this->actingAs($user, 'sanctum')
+            ->postJson('/api/staking/reinvest', [
+                'staking_package_id' => $discovery->id,
+                'amount' => $expected,
+                'source' => 'claimable_bonus',
+            ]);
+        $rein->assertCreated();
+        $user->refresh();
+        $this->assertEquals(0.0, (float) $user->claimable_bonus_balance);
+        $this->assertEquals(50 + $expected, (float) $investment->fresh()->amount);
+
+        // Reserve withdrawal and admin reject (to test unlock)
+        $user->increment('pending_withdrawal', 5.0);
+        $wr = WithdrawalRequest::create([
+            'user_id' => $user->id,
+            'amount' => 5.0,
+            'status' => 'pending',
+        ]);
+        Transaction::create([
+            'user_id' => $user->id,
+            'type' => 'withdrawal',
+            'category' => 'withdrawal',
+            'amount' => 0,
+            'balance_before' => $user->balance_pi,
+            'balance_after' => $user->balance_pi,
+            'status' => 'pending',
+            'withdrawal_request_id' => $wr->id,
+        ]);
+        $rej = $this->actingAs($admin, 'sanctum')
+            ->patchJson("/api/admin/withdrawals/{$wr->id}", [
+                'action' => 'reject',
+                'reason' => 'manual_test',
+            ]);
+        $rej->assertOk();
+        $this->assertEquals(0.0, (float) $user->fresh()->pending_withdrawal);
+    }
+}

--- a/pi-staking/pi-staking-frontend/src/components/UserDashboardComplete.tsx
+++ b/pi-staking/pi-staking-frontend/src/components/UserDashboardComplete.tsx
@@ -98,6 +98,8 @@ export function UserDashboardComplete({ onLogout }: UserDashboardCompleteProps) 
   // Données pour les graphiques et statistiques
   const [performanceData, setPerformanceData] = useState<any[]>([]);
   const [withdrawalLimits, setWithdrawalLimits] = useState({ daily: 0, monthly: 0 });
+  const [reinvestForm, setReinvestForm] = useState<{ source: 'claimable' | 'claimable_bonus'; packageId: string; amount: string }>({ source: 'claimable', packageId: '', amount: '' });
+  const [reinvestLoading, setReinvestLoading] = useState(false);
 
   // État pour les modales
   const [showInvestModal, setShowInvestModal] = useState(false);
@@ -262,6 +264,8 @@ export function UserDashboardComplete({ onLogout }: UserDashboardCompleteProps) 
   };
 
   const normalizedPackages = Array.isArray(packages) ? packages : (packages as any)?.packages || [];
+  const discoveryPackages = normalizedPackages.filter((p: any) => p.is_discovery_bonus);
+  const regularPackages = normalizedPackages.filter((p: any) => !p.is_discovery_bonus);
   const safeInvestments = Array.isArray(investments) ? investments : [];
   const calculatedTotalInvested = safeInvestments.reduce((sum, inv) => sum + inv.amount, 0) || 0;
   const totalEarnings = safeInvestments.reduce((sum, inv) => sum + (inv.total_earned || 0), 0) || 0;
@@ -313,6 +317,70 @@ export function UserDashboardComplete({ onLogout }: UserDashboardCompleteProps) 
     const id = setInterval(update, 1000);
     return () => clearInterval(id);
   }, [activeWelcomeGrant?.expires_at]);
+
+  const handleReinvest = async () => {
+    try {
+      setReinvestLoading(true);
+      const pkgId = reinvestForm.packageId || (reinvestForm.source === 'claimable_bonus' ? discoveryPackages[0]?.id : regularPackages[0]?.id);
+      if (!pkgId) {
+        window.alert('Aucun package disponible pour ce réinvestissement');
+        setReinvestLoading(false);
+        return;
+      }
+      const amountNum = parseFloat(reinvestForm.amount);
+      if (!amountNum || amountNum <= 0) {
+        window.alert('Montant invalide');
+        setReinvestLoading(false);
+        return;
+      }
+      // Règles côté client
+      const cb = Number((user as any)?.claimable_balance || 0);
+      const cbb = Number((user as any)?.claimable_bonus_balance || 0);
+      if (reinvestForm.source === 'claimable' && amountNum > cb) {
+        window.alert('Montant supérieur à votre solde de gains réinvestissables');
+        setReinvestLoading(false);
+        return;
+      }
+      if (reinvestForm.source === 'claimable_bonus' && amountNum > cbb) {
+        window.alert('Montant supérieur à votre solde de gains bonus réinvestissables');
+        setReinvestLoading(false);
+        return;
+      }
+      const chosen = normalizedPackages.find((p: any) => p.id === pkgId);
+      if (chosen) {
+        if (reinvestForm.source === 'claimable_bonus' && !chosen.is_discovery_bonus) {
+          window.alert('Les gains bonus ne peuvent être réinvestis que dans le package Discovery');
+          setReinvestLoading(false);
+          return;
+        }
+        if (amountNum < chosen.min_amount) {
+          window.alert(`Le montant doit être ≥ ${formatCurrency(chosen.min_amount)} π`);
+          setReinvestLoading(false);
+          return;
+        }
+        if (chosen.max_amount && amountNum > chosen.max_amount) {
+          window.alert(`Le montant doit être ≤ ${formatCurrency(chosen.max_amount)} π`);
+          setReinvestLoading(false);
+          return;
+        }
+      }
+
+      const res = await stakingService.reinvest(String(pkgId), amountNum, reinvestForm.source);
+      if (!res.success) {
+        window.alert(res.message || 'Échec du réinvestissement');
+      } else {
+        window.alert('Réinvestissement effectué avec succès');
+        setReinvestForm({ ...reinvestForm, amount: '' });
+        await refreshAllData();
+        await refreshUser();
+      }
+    } catch (e) {
+      console.error(e);
+      window.alert('Erreur lors du réinvestissement');
+    } finally {
+      setReinvestLoading(false);
+    }
+  };
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-background via-background to-muted/20 relative">
@@ -458,44 +526,40 @@ export function UserDashboardComplete({ onLogout }: UserDashboardCompleteProps) 
 
               <GlowCard>
                 <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-                  <CardTitle className="text-sm font-medium">Gains Totaux</CardTitle>
+                  <CardTitle className="text-sm font-medium">Solde disponible</CardTitle>
+                  <Wallet className="h-4 w-4 text-muted-foreground" />
+                </CardHeader>
+                <CardContent>
+                  <div className="text-2xl font-bold">
+                    {formatCurrency(Number((user as any)?.balance_pi || 0) - Number((user as any)?.pending_withdrawal || 0))} π
+                  </div>
+                  <p className="text-xs text-muted-foreground">Après réservations de retraits</p>
+                </CardContent>
+              </GlowCard>
+
+              <GlowCard>
+                <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+                  <CardTitle className="text-sm font-medium">Gains réinvestissables</CardTitle>
                   <TrendingUp className="h-4 w-4 text-green-500" />
                 </CardHeader>
                 <CardContent>
                   <div className="text-2xl font-bold text-green-600">
-                    +{formatCurrency(totalEarnings)} π
+                    {formatCurrency(Number((user as any)?.claimable_balance || 0))} π
                   </div>
-                  <p className="text-xs text-muted-foreground">
-                    {totalEarnings > 0 ? `+${((totalEarnings / calculatedTotalInvested) * 100).toFixed(2)}%` : '0%'} ROI
-                  </p>
+                  <p className="text-xs text-muted-foreground">Réinvestissable dans n'importe quel package</p>
                 </CardContent>
               </GlowCard>
 
               <GlowCard>
                 <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-                  <CardTitle className="text-sm font-medium">À Réclamer</CardTitle>
+                  <CardTitle className="text-sm font-medium">Gains bonus réinvestissables</CardTitle>
                   <Gift className="h-4 w-4 text-pi-gold" />
                 </CardHeader>
                 <CardContent>
                   <div className="text-2xl font-bold text-pi-gold">
-                    {formatCurrency(totalClaimable)} π
+                    {formatCurrency(Number((user as any)?.claimable_bonus_balance || 0))} π
                   </div>
-                  <p className="text-xs text-muted-foreground">
-                    {claimableInvestments?.length || 0} réclamations disponibles
-                  </p>
-                </CardContent>
-              </GlowCard>
-
-              <GlowCard>
-                <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-                  <CardTitle className="text-sm font-medium">Niveau</CardTitle>
-                  <Award className="h-4 w-4 text-pi-gold" />
-                </CardHeader>
-                <CardContent>
-                  <div className="text-2xl font-bold text-pi-gold">OR</div>
-                  <p className="text-xs text-muted-foreground">
-                    {user?.loyalty_points || 0} points de fidélité
-                  </p>
+                  <p className="text-xs text-muted-foreground">Réinvestissable seulement dans Discovery</p>
                 </CardContent>
               </GlowCard>
             </div>
@@ -537,6 +601,59 @@ export function UserDashboardComplete({ onLogout }: UserDashboardCompleteProps) 
                 </CardContent>
               </GlowCard>
             )}
+
+            {/* Réinvestissement depuis gains */}
+            <GlowCard>
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2">
+                  <TrendingUp className="h-5 w-5" /> Réinvestir mes gains
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-3">
+                <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
+                  <div>
+                    <Label>Source</Label>
+                    <select
+                      className="w-full border rounded-md h-10 px-2 bg-background"
+                      value={reinvestForm.source}
+                      onChange={(e) => setReinvestForm({ ...reinvestForm, source: e.target.value as any, packageId: '' })}
+                    >
+                      <option value="claimable">Gains</option>
+                      <option value="claimable_bonus">Gains bonus (Discovery)</option>
+                    </select>
+                  </div>
+                  <div>
+                    <Label>Package</Label>
+                    <select
+                      className="w-full border rounded-md h-10 px-2 bg-background"
+                      value={reinvestForm.packageId}
+                      onChange={(e) => setReinvestForm({ ...reinvestForm, packageId: e.target.value })}
+                    >
+                      {(reinvestForm.source === 'claimable' ? regularPackages : discoveryPackages).map((p: any) => (
+                        <option key={p.id} value={p.id}>{p.name}</option>
+                      ))}
+                    </select>
+                  </div>
+                  <div>
+                    <Label>Montant (π)</Label>
+                    <Input
+                      type="number"
+                      placeholder="0.00"
+                      value={reinvestForm.amount}
+                      onChange={(e) => setReinvestForm({ ...reinvestForm, amount: e.target.value })}
+                    />
+                  </div>
+                </div>
+                <div className="flex justify-end">
+                  <Button onClick={handleReinvest} disabled={reinvestLoading} className="pi-gradient text-white hover:pi-gradient-hover">
+                    {reinvestLoading ? 'Réinvestissement...' : 'Réinvestir'}
+                  </Button>
+                </div>
+                <p className="text-xs text-muted-foreground">
+                  Solde gains: {formatCurrency(Number((user as any)?.claimable_balance || 0))} π • Gains bonus: {formatCurrency(Number((user as any)?.claimable_bonus_balance || 0))} π • Réservé: {formatCurrency(Number((user as any)?.pending_withdrawal || 0))} π
+                </p>
+              </CardContent>
+            </GlowCard>
 
             {/* Actions Rapides */}
             <div className="grid grid-cols-1 md:grid-cols-3 gap-4">

--- a/pi-staking/pi-staking-frontend/src/index.css
+++ b/pi-staking/pi-staking-frontend/src/index.css
@@ -53,39 +53,41 @@
   --card-foreground: oklch(0.145 0 0);
   --popover: oklch(0.98 0.012 283);
   --popover-foreground: oklch(0.145 0 0);
-  --primary: oklch(0.54 0.196 283);
-  --primary-foreground: oklch(0.985 0 0);
-  --secondary: oklch(0.85 0.08 48);
-  --secondary-foreground: oklch(0.16 0.04 283);
-  --muted: oklch(0.92 0.02 283);
-  --muted-foreground: oklch(0.556 0 0);
-  --accent: oklch(0.85 0.08 48);
-  --accent-foreground: oklch(0.16 0.04 283);
-  --destructive: oklch(0.577 0.245 27.325);
-  --border: oklch(0.88 0.04 283);
-  --input: oklch(0.92 0.02 283);
-  --ring: oklch(0.54 0.196 283);
-  --chart-1: oklch(0.54 0.196 283);
-  --chart-2: oklch(0.85 0.08 48);
-  --chart-3: oklch(0.65 0.15 310);
-  --chart-4: oklch(0.75 0.12 50);
-  --chart-5: oklch(0.45 0.18 285);
-  --sidebar: oklch(0.98 0.012 283);
-  --sidebar-foreground: oklch(0.145 0 0);
-  --sidebar-primary: oklch(0.54 0.196 283);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.92 0.02 283);
-  --sidebar-accent-foreground: oklch(0.16 0.04 283);
-  --sidebar-border: oklch(0.88 0.04 283);
-  --sidebar-ring: oklch(0.54 0.196 283);
+  --primary: var(--pi-purple);
+  --primary-foreground: #ffffff;
+  --secondary: var(--pi-gold);
+  --secondary-foreground: #1a1a1a;
+  --muted: #f3f4f6;
+  --muted-foreground: #6b7280;
+  --accent: var(--pi-gold);
+  --accent-foreground: #1a1a1a;
+  --destructive: #ef4444;
+  --border: #e5e7eb;
+  --input: #f3f4f6;
+  --ring: var(--pi-purple);
+  --chart-1: var(--pi-purple);
+  --chart-2: var(--pi-gold);
+  --chart-3: #8b5cf6;
+  --chart-4: #f59e0b;
+  --chart-5: #4f46e5;
+  --sidebar: #ffffff;
+  --sidebar-foreground: #111827;
+  --sidebar-primary: var(--pi-purple);
+  --sidebar-primary-foreground: #ffffff;
+  --sidebar-accent: #f3f4f6;
+  --sidebar-accent-foreground: #111827;
+  --sidebar-border: #e5e7eb;
+  --sidebar-ring: var(--pi-purple);
   
-  /* Pi Network custom colors */
-  --pi-purple: oklch(0.54 0.196 283);
-  --pi-purple-light: oklch(0.65 0.15 285);
-  --pi-purple-dark: oklch(0.45 0.18 280);
-  --pi-gold: oklch(0.85 0.08 48);
-  --pi-gold-light: oklch(0.9 0.06 50);
-  --pi-gold-dark: oklch(0.75 0.12 45);
+  /* Brand colors */
+  --pi-purple: #612E9D;
+  --pi-purple-light: #7B4BBF;
+  --pi-purple-dark: #4A2277;
+  --pi-gold: #F5C73A;
+  --pi-gold-light: #FFD96A;
+  --pi-gold-dark: #D4A72E;
+  --pi-purple-rgb: 97, 46, 157;
+  --pi-gold-rgb: 245, 199, 58;
 }
 
 .dark {
@@ -95,39 +97,41 @@
   --card-foreground: oklch(0.985 0 0);
   --popover: oklch(0.12 0.02 283);
   --popover-foreground: oklch(0.985 0 0);
-  --primary: oklch(0.7 0.15 283);
-  --primary-foreground: oklch(0.08 0.015 283);
-  --secondary: oklch(0.85 0.08 48);
-  --secondary-foreground: oklch(0.08 0.015 283);
-  --muted: oklch(0.15 0.025 283);
-  --muted-foreground: oklch(0.708 0 0);
-  --accent: oklch(0.85 0.08 48);
-  --accent-foreground: oklch(0.08 0.015 283);
-  --destructive: oklch(0.704 0.191 22.216);
-  --border: oklch(0.2 0.03 283);
-  --input: oklch(0.15 0.025 283);
-  --ring: oklch(0.7 0.15 283);
-  --chart-1: oklch(0.7 0.15 283);
-  --chart-2: oklch(0.85 0.08 48);
-  --chart-3: oklch(0.75 0.12 310);
-  --chart-4: oklch(0.8 0.1 50);
-  --chart-5: oklch(0.6 0.18 285);
-  --sidebar: oklch(0.08 0.015 283);
-  --sidebar-foreground: oklch(0.985 0 0);
-  --sidebar-primary: oklch(0.7 0.15 283);
-  --sidebar-primary-foreground: oklch(0.08 0.015 283);
-  --sidebar-accent: oklch(0.15 0.025 283);
-  --sidebar-accent-foreground: oklch(0.985 0 0);
-  --sidebar-border: oklch(0.2 0.03 283);
-  --sidebar-ring: oklch(0.7 0.15 283);
+  --primary: var(--pi-purple);
+  --primary-foreground: #0b0b0b;
+  --secondary: var(--pi-gold);
+  --secondary-foreground: #0b0b0b;
+  --muted: #1f2937;
+  --muted-foreground: #9ca3af;
+  --accent: var(--pi-gold);
+  --accent-foreground: #0b0b0b;
+  --destructive: #b91c1c;
+  --border: #374151;
+  --input: #1f2937;
+  --ring: var(--pi-purple);
+  --chart-1: var(--pi-purple);
+  --chart-2: var(--pi-gold);
+  --chart-3: #a78bfa;
+  --chart-4: #fbbf24;
+  --chart-5: #6366f1;
+  --sidebar: #0b0b0b;
+  --sidebar-foreground: #f9fafb;
+  --sidebar-primary: var(--pi-purple);
+  --sidebar-primary-foreground: #0b0b0b;
+  --sidebar-accent: #1f2937;
+  --sidebar-accent-foreground: #f9fafb;
+  --sidebar-border: #374151;
+  --sidebar-ring: var(--pi-purple);
   
-  /* Pi Network custom colors for dark mode */
-  --pi-purple: oklch(0.7 0.15 283);
-  --pi-purple-light: oklch(0.8 0.12 285);
-  --pi-purple-dark: oklch(0.5 0.2 280);
-  --pi-gold: oklch(0.85 0.08 48);
-  --pi-gold-light: oklch(0.9 0.06 50);
-  --pi-gold-dark: oklch(0.75 0.12 45);
+  /* Brand colors (dark) */
+  --pi-purple: #7B4BBF;
+  --pi-purple-light: #9C74D6;
+  --pi-purple-dark: #4A2277;
+  --pi-gold: #F5C73A;
+  --pi-gold-light: #FFD96A;
+  --pi-gold-dark: #D4A72E;
+  --pi-purple-rgb: 123, 75, 191;
+  --pi-gold-rgb: 245, 199, 58;
 }
 
 @layer base {
@@ -141,39 +145,28 @@
 
 @layer utilities {
   .pi-gradient {
-    background: linear-gradient(135deg, oklch(var(--pi-purple)), oklch(var(--pi-gold)));
+    background: linear-gradient(135deg, var(--pi-purple), var(--pi-gold));
   }
   
   .pi-gradient-hover {
-    background: linear-gradient(135deg, oklch(var(--pi-purple-light)), oklch(var(--pi-gold-light)));
+    background: linear-gradient(135deg, var(--pi-purple-light), var(--pi-gold-light));
   }
   
   .pi-gradient-radial {
-    background: radial-gradient(ellipse at center, oklch(var(--pi-purple) / 0.3), oklch(var(--pi-gold) / 0.2), transparent);
+    background: radial-gradient(ellipse at center, rgba(var(--pi-purple-rgb), 0.3), rgba(var(--pi-gold-rgb), 0.2), transparent);
   }
   
-  .pi-purple {
-    color: oklch(var(--pi-purple));
-  }
-  
-  .bg-pi-purple {
-    background-color: oklch(var(--pi-purple));
-  }
-  
-  .pi-gold {
-    color: oklch(var(--pi-gold));
-  }
-  
-  .bg-pi-gold {
-    background-color: oklch(var(--pi-gold));
-  }
+  .pi-purple { color: var(--pi-purple); }
+  .bg-pi-purple { background-color: var(--pi-purple); }
+  .pi-gold { color: var(--pi-gold); }
+  .bg-pi-gold { background-color: var(--pi-gold); }
   
   .glow-pi {
-    box-shadow: 0 0 20px oklch(var(--pi-purple) / 0.5), 0 0 40px oklch(var(--pi-gold) / 0.3);
+    box-shadow: 0 0 20px rgba(var(--pi-purple-rgb), 0.5), 0 0 40px rgba(var(--pi-gold-rgb), 0.3);
   }
   
   .glow-pi-strong {
-    box-shadow: 0 0 30px oklch(var(--pi-purple) / 0.7), 0 0 60px oklch(var(--pi-gold) / 0.5), 0 0 100px oklch(var(--pi-purple) / 0.3);
+    box-shadow: 0 0 30px rgba(var(--pi-purple-rgb), 0.7), 0 0 60px rgba(var(--pi-gold-rgb), 0.5), 0 0 100px rgba(var(--pi-purple-rgb), 0.3);
   }
   
   .animate-pi-pulse {
@@ -205,7 +198,7 @@
   }
   
   .text-pi-gradient {
-    background: linear-gradient(135deg, oklch(var(--pi-purple)), oklch(var(--pi-gold)));
+    background: linear-gradient(135deg, var(--pi-purple), var(--pi-gold));
     -webkit-background-clip: text;
     -webkit-text-fill-color: transparent;
     background-clip: text;

--- a/pi-staking/pi-staking-frontend/src/services/stakingService.ts
+++ b/pi-staking/pi-staking-frontend/src/services/stakingService.ts
@@ -184,6 +184,29 @@ class StakingService {
     }
   }
 
+  // Réinvestir depuis les soldes claimables
+  async reinvest(
+    packageId: string,
+    amount: number,
+    source: 'claimable' | 'claimable_bonus'
+  ): Promise<{ success: boolean; message: string; data: any }> {
+    try {
+      const response = await api.post('/staking/reinvest', {
+        staking_package_id: packageId,
+        amount,
+        source,
+      });
+      return response.data;
+    } catch (error: any) {
+      console.error('Erreur lors du réinvestissement:', error);
+      return {
+        success: false,
+        data: null,
+        message: error.response?.data?.message || 'Impossible de réinvestir',
+      };
+    }
+  }
+
   // ✅ Calculer les statistiques de staking pour l'utilisateur
   async getStakingStats(): Promise<{
     success: boolean;


### PR DESCRIPTION
# Consolidate staking logic: claimable balances, reinvest, admin withdrawals reservations, scheduler, admin export, theme

## Summary
This PR makes the staking flow fully functional end‑to‑end and aligns with the confirmed constraints:
- Daily accrual scheduler at 00:05 WAT (configurable), idempotent.
- Claimable balances introduced (no mixing with available balance).
- Reinvestment flows from claimable (regular) and claimable bonus (Discovery‑only).
- Withdrawals use reservations (pending_withdrawal) on request, definitive debit on admin approval; no external payout automation.
- Admin area strengthened (exports, approvals/rejections); Spatie role + email allowlist respected.
- Frontend updated with a vivid purple/gold theme and a complete reinvest UI.

## Key changes
- Backend
  - Add daily earnings schedule at 00:05 WAT in Console Kernel; run with timezone env `SCHEDULER_TZ`.
  - Idempotent accrual: one claim per (investment, day) with migration constraint already present.
  - Introduce user balances: `claimable_balance`, `claimable_bonus_balance`, `pending_withdrawal`.
  - ClaimService credits claimable balances (not available balance). Bonus‑origin investments credit `claimable_bonus_balance`.
  - New endpoint `POST /api/staking/reinvest`:
    - `source=claimable` → can reinvest to regular packages (min/max enforced).
    - `source=claimable_bonus` → Discovery‑only, anti‑abuse: first creates a bonus investment, subsequent reinvest compounding on the existing bonus investment.
  - Withdrawals: request reserves funds into `pending_withdrawal`; admin approve debits definitively and clears reservation; reject frees reservation and restores consistency.
  - Admin transactions CSV export uses English canonical headers: `id,user_email,type,status,amount,tx_hash,reference_id,created_at_utc`.
  - Admin dashboard endpoint fixed to compute users/alerts/popular packages without undefined vars.
  - Discovery‑only rules enforced for bonus and bonus‑origin gains; one bonus investment per user (compound allowed).

- Frontend (pi-staking-frontend)
  - Theme updated: purple #612E9D and gold #F5C73A (gradients, accents, utilities).
  - Dashboard now displays: available (after reservations), `claimable_balance`, `claimable_bonus_balance`, and `pending_withdrawal`.
  - New reinvest UI wired to `POST /api/staking/reinvest` with client‑side validations and discovery‑only restrictions for bonus gains.

- Tests (PHPUnit)
  - End‑to‑end tests cover:
    - Deposit → stake (funds) → accrual → claim → reinvest from claimable → withdrawal request reservation → admin approve (debit) → reservation clears.
    - Bonus cycle: claim bonus → stake Discovery (bonus) → accrual → claim to claimable_bonus → reinvest claimable_bonus (compound) → withdrawal reservation → admin reject (reservation cleared).
  - Updated admin withdrawals tests to the reservation model.
  - Updated admin transactions export test to English headers.

## Migrations
New migration adds user fields:
- `claimable_balance` (decimal 16,8)
- `claimable_bonus_balance` (decimal 16,8)
- `pending_withdrawal` (decimal 16,8)

Run:
```
php artisan migrate
```

## Scheduling
- Daily accrual: `staking:process-daily-earnings` scheduled at 00:05 in `Africa/Lagos` by default. Set `SCHEDULER_TZ` to override.
- The command is idempotent and safe to rerun.

## Admin access
- Guarded routes under `Route::prefix('admin')->middleware('admin.access')`.
- Spatie role: `admin` OR fallback allowlist via `ADMIN_EMAILS` (e.g. `admin@progressiverewards.com`).

## Endpoints touched
- `POST /api/staking/reinvest` (new)
- `POST /api/staking/reinvest-bonus` (existing bonus quick reinvest)
- `POST /api/staking/invest`
- `POST /api/deposit/request`, `POST /api/admin/deposits/{id}/confirm`
- `POST /api/transactions/withdrawal` (reservation semantics applied internally) and admin `PATCH /api/admin/withdrawals/{id}` approve/reject.

## Notes
- No external payouts are automated; admin approves finalize debits only.
- All critical fund movements create a Transaction linked to the causal entity (investment/claim/withdrawal/deposit) and are logged on the daily channel.

## Impact
- Requires DB migration.
- Frontend expects new user fields from `/auth/me` and updated limits/stats; compatible changes are included.

## Checklist
- [x] Idempotent daily accrual, one claim per day/investment
- [x] Claimable balances + reinvest flows
- [x] Discovery‑only enforcement for bonus/gains
- [x] Withdrawal reservations model + admin approval/reject
- [x] Admin CSV export canonical headers
- [x] Frontend theme + reinvest UI
- [x] E2E tests for funds and bonus flows

Please review and let me know if you want separate PRs for backend/FE split or additional admin metrics/UI refinements.

₍ᐢ•(ܫ)•ᐢ₎ Generated by [Capy](https://capy.ai) ([view task](https://capy.ai/project/57292b1c-84af-11f0-a94e-3eef481a796b/task/2f8b5aa7-d30e-480d-9cb5-4cdd5b3e1200))