### PR TITLE
FinOps Phase 1: Idempotent claims, rounding policy, double-entry ledger, reconciliation

### DIFF
--- a/pi-staking/apps/backend/README.md
+++ b/pi-staking/apps/backend/README.md
@@ -24,3 +24,19 @@ php artisan optimize:clear
 php artisan route:clear
 php artisan config:clear
 ```
+
+FinOps
+
+- Politique d’arrondi centralisée via `config/finance.php`:
+  - `rounding_mode`: `half_even` par défaut (banquier), options: `half_up`, `floor`
+  - `scale`: 8 décimales
+- Utilitaires monétaires `App\Support\Money` (wrappers BCMath): `add`, `sub`, `mul`, `div`, `cmp`, `round`, `formatPi`.
+- Grand livre (double-entrée) table `ledger_entries` (comptes: `principal`, `bonus`, `claimable`, `claimable_bonus`, `pending_withdrawal`, `fees`, `external`).
+  - Service `App\Services\LedgerService` avec `post`, `move`, `moveExternalToUser`, `moveUserToExternal`.
+  - Intégrations clés:
+    - Dépôt: `external -> principal`
+    - Staking (création / reinvest): `principal|bonus|claimable|claimable_bonus -> external`
+    - Claim quotidien: `external -> claimable|claimable_bonus`
+    - Retrait (réservation): `principal -> pending_withdrawal`, (approbation): `pending_withdrawal -> external`, (annulation/rejet): `pending_withdrawal -> principal`
+- Réconciliation: `php artisan finance:reconcile-users --dry-run` reconstruit les soldes à partir du ledger et compare aux colonnes `users`. Le solde `balance_pi` est dérivé comme `principal + pending_withdrawal`.
+

--- a/pi-staking/apps/backend/app/Console/Commands/ProcessDailyEarnings.php
+++ b/pi-staking/apps/backend/app/Console/Commands/ProcessDailyEarnings.php
@@ -27,56 +27,64 @@ class ProcessDailyEarnings extends Command
         $skipped = 0;
         $completed = 0;
         $errors = 0;
+        $locked = 0;
 
-        $investments = Investment::with(['user', 'stakingPackage'])
+        Investment::with(['user', 'stakingPackage'])
             ->where('status', 'active')
-            ->get();
+            ->orderBy('id')
+            ->chunkById(500, function ($chunk) use (&$processed, &$skipped, &$completed, &$errors, &$locked, $claimService, $runDate, $today) {
+                foreach ($chunk as $investment) {
+                    try {
+                        if ($investment->end_at && $runDate->greaterThanOrEqualTo($investment->end_at)) {
+                            $investment->update(['status' => 'completed']);
+                            $completed++;
+                            continue;
+                        }
 
-        foreach ($investments as $investment) {
-            try {
-                // Marquer terminé si arrivé à échéance
-                if ($investment->end_at && $runDate->greaterThanOrEqualTo($investment->end_at)) {
-                    $investment->update(['status' => 'completed']);
-                    $completed++;
-                    continue;
+                        $alreadyClaimedToday = $investment->claims()
+                            ->where('claimed_for_day', $today)
+                            ->exists();
+                        if ($alreadyClaimedToday) {
+                            $skipped++;
+                            continue;
+                        }
+
+                        $lock = \Illuminate\Support\Facades\Cache::lock('claim:investment:' . $investment->id, 10);
+                        if (!$lock->get()) {
+                            $locked++;
+                            continue;
+                        }
+                        try {
+                            if ($investment->canClaim()) {
+                                $claimService->processClaim($investment->user, $investment, $today);
+                                $processed++;
+                            } else {
+                                $skipped++;
+                            }
+                        } finally {
+                            optional($lock)->release();
+                        }
+                    } catch (\Throwable $e) {
+                        $errors++;
+                        Log::channel('daily')->error('[staking] Erreur traitement gains', [
+                            'investment_id' => $investment->id,
+                            'user_id' => $investment->user_id,
+                            'message' => $e->getMessage(),
+                        ]);
+                    }
                 }
-
-                // Sauter si déjà enregistré pour aujourd'hui
-                $alreadyClaimedToday = $investment->claims()
-                    ->where('claimed_for_day', $today)
-                    ->exists();
-
-                if ($alreadyClaimedToday) {
-                    $skipped++;
-                    continue;
-                }
-
-                // Si claim disponible selon la logique existante, traiter via ClaimService
-                if ($investment->canClaim()) {
-                    $claimService->processClaim($investment->user, $investment);
-                    $processed++;
-                } else {
-                    $skipped++;
-                }
-            } catch (\Throwable $e) {
-                $errors++;
-                Log::channel('daily')->error('[staking] Erreur traitement gains', [
-                    'investment_id' => $investment->id,
-                    'user_id' => $investment->user_id,
-                    'message' => $e->getMessage(),
-                ]);
-            }
-        }
+            });
 
         Log::channel('daily')->info('[staking] Fin traitement des gains quotidiens', [
             'date' => $today,
             'processed' => $processed,
             'skipped' => $skipped,
             'completed' => $completed,
+            'locked' => $locked,
             'errors' => $errors,
         ]);
 
-        $this->info("Traitement terminé: {$processed} traités, {$skipped} ignorés, {$completed} complétés, {$errors} erreurs.");
+        $this->info("Traitement terminé: {$processed} traités, {$skipped} ignorés, {$completed} complétés, {$locked} verrouillés, {$errors} erreurs.");
 
         return self::SUCCESS;
     }

--- a/pi-staking/apps/backend/app/Console/Commands/ReconcileUsers.php
+++ b/pi-staking/apps/backend/app/Console/Commands/ReconcileUsers.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\LedgerEntry;
+use App\Models\User;
+use Illuminate\Console\Command;
+
+class ReconcileUsers extends Command
+{
+    protected $signature = 'finance:reconcile-users {--dry-run}';
+
+    protected $description = 'Recalcule les soldes à partir du ledger et compare avec la table users.';
+
+    public function handle(): int
+    {
+        $dry = (bool) $this->option('dry-run');
+        $this->info('Reconciliation des utilisateurs ' . ($dry ? '(dry-run)' : ''));
+
+        $discrepancies = [];
+        $totalUsers = 0;
+
+        User::chunkById(500, function ($chunk) use (&$discrepancies, &$totalUsers, $dry) {
+            foreach ($chunk as $user) {
+                $totalUsers++;
+                $sums = LedgerEntry::where('user_id', $user->id)
+                    ->selectRaw('account, COALESCE(SUM(delta),0) as total')
+                    ->groupBy('account')
+                    ->pluck('total', 'account');
+
+                $principal = (float) ($sums['principal'] ?? 0);
+                $bonus = (float) ($sums['bonus'] ?? 0);
+                $claimable = (float) ($sums['claimable'] ?? 0);
+                $claimableBonus = (float) ($sums['claimable_bonus'] ?? 0);
+                $pending = (float) ($sums['pending_withdrawal'] ?? 0);
+
+                $derivedBalancePi = $principal + $pending;
+
+                $diffs = [];
+                $this->compare('balance_pi', $derivedBalancePi, (float) $user->balance_pi, $diffs);
+                $this->compare('bonus_balance', $bonus, (float) $user->bonus_balance, $diffs);
+                $this->compare('claimable_balance', $claimable, (float) $user->claimable_balance, $diffs);
+                $this->compare('claimable_bonus_balance', $claimableBonus, (float) $user->claimable_bonus_balance, $diffs);
+                $this->compare('pending_withdrawal', $pending, (float) $user->pending_withdrawal, $diffs);
+
+                if (!empty($diffs)) {
+                    $discrepancies[$user->id] = $diffs;
+                    $this->warn("User {$user->id} discrepancies: " . json_encode($diffs));
+                }
+
+                if (!$dry && empty($diffs)) {
+                    // nothing to do
+                }
+            }
+        });
+
+        if (empty($discrepancies)) {
+            $this->info("Reconciliation OK. Aucun écart sur {$totalUsers} utilisateur(s).");
+            return self::SUCCESS;
+        }
+
+        $this->error('Des écarts ont été détectés.');
+        $this->line(json_encode($discrepancies, JSON_PRETTY_PRINT));
+        return self::SUCCESS;
+    }
+
+    private function compare(string $label, float $derived, float $actual, array &$diffs): void
+    {
+        $eps = 1e-8;
+        $delta = $derived - $actual;
+        if (abs($delta) > $eps) {
+            $diffs[$label] = [
+                'derived' => round($derived, 8),
+                'actual' => round($actual, 8),
+                'delta' => round($delta, 8),
+            ];
+        }
+    }
+}

--- a/pi-staking/apps/backend/app/Http/Controllers/AdminWithdrawalController.php
+++ b/pi-staking/apps/backend/app/Http/Controllers/AdminWithdrawalController.php
@@ -147,6 +147,10 @@ class AdminWithdrawalController extends Controller
                 $txn->admin_notes = $validated['admin_notes'] ?? null;
                 $txn->save();
 
+                app(\App\Services\LedgerService::class)->moveUserToExternal($user->id, 'pending_withdrawal', $withdrawal->amount, 'withdrawal', (string) $withdrawal->id, [
+                    'transaction_id' => $txn->id,
+                ]);
+
                 Log::channel('daily')->info('Approbation admin d\'un retrait', [
                     'action' => 'admin_withdrawal_approved',
                     'admin_id' => $admin->id,
@@ -218,6 +222,10 @@ class AdminWithdrawalController extends Controller
                 $withdrawal->admin_notes = $validated['admin_notes'];
             }
             $withdrawal->save();
+
+            app(\App\Services\LedgerService::class)->move($user->id, 'pending_withdrawal', $user->id, 'principal', $withdrawal->amount, 'withdrawal_reject', (string) $withdrawal->id, [
+                'transaction_id' => $txn?->id,
+            ]);
 
             Log::channel('daily')->info('Rejet admin d\'un retrait', [
                 'action' => 'admin_withdrawal_rejected',

--- a/pi-staking/apps/backend/app/Http/Controllers/StakingController.php
+++ b/pi-staking/apps/backend/app/Http/Controllers/StakingController.php
@@ -155,6 +155,10 @@ class StakingController extends Controller
                         $existing->update(['amount' => $newAmount]);
                         $user->decrement('claimable_bonus_balance', $amount);
 
+                        app(\App\Services\LedgerService::class)->moveUserToExternal($user->id, 'claimable_bonus', $amount, 'investment_compound', (string) $existing->id, [
+                            'package_id' => $package->id,
+                        ]);
+
                         Transaction::create([
                             'user_id' => $user->id,
                             'type' => 'adjustment',

--- a/pi-staking/apps/backend/app/Http/Controllers/TransactionController.php
+++ b/pi-staking/apps/backend/app/Http/Controllers/TransactionController.php
@@ -11,6 +11,9 @@ use Illuminate\Support\Facades\DB;
 
 class TransactionController extends Controller
 {
+    public function __construct(private \App\Services\LedgerService $ledgerService)
+    {
+    }
     /**
      * Créer une demande de retrait
      */
@@ -87,6 +90,9 @@ class TransactionController extends Controller
                     'note' => $request->note,
                     'requested_at' => now(),
                 ]);
+
+                // Ledger: réserver en déplaçant principal -> pending_withdrawal
+                $this->ledgerService->move($user->id, 'principal', $user->id, 'pending_withdrawal', $amount, 'withdrawal_request', (string) $withdrawalRequest->id, []);
 
                 // Créer la transaction de réservation (montant 0, statut pending)
                 Transaction::create([
@@ -257,6 +263,8 @@ class TransactionController extends Controller
             DB::transaction(function () use ($withdrawal, $user) {
                 // Libérer la réservation
                 $user->decrement('pending_withdrawal', $withdrawal->amount);
+
+                $this->ledgerService->move($user->id, 'pending_withdrawal', $user->id, 'principal', $withdrawal->amount, 'withdrawal_cancel', (string) $withdrawal->id, []);
                 
                 // Marquer comme annulée
                 $withdrawal->update([

--- a/pi-staking/apps/backend/app/Models/Investment.php
+++ b/pi-staking/apps/backend/app/Models/Investment.php
@@ -144,15 +144,13 @@ class Investment extends Model
      */
     public function calculateNextClaimAmount(): float
     {
-        $baseAmount = $this->amount * $this->daily_rate * $this->bonus_multiplier;
-        
-        // Appliquer les bonus de streak si éligible
+        $base = \App\Support\Money::mul($this->amount, $this->daily_rate);
+        $adj = \App\Support\Money::mul($base, $this->bonus_multiplier);
         if ($this->stakingPackage->features['streak_bonus_eligible'] ?? false) {
-            $streakBonus = $this->user->streak_bonus;
-            $baseAmount *= (1 + $streakBonus);
+            $streak = $this->user->streak_bonus ?? 0;
+            $adj = \App\Support\Money::mul($adj, (string) (1 + (float) $streak));
         }
-
-        return round($baseAmount, 8);
+        return (float) \App\Support\Money::round($adj);
     }
 
     /**

--- a/pi-staking/apps/backend/app/Models/LedgerEntry.php
+++ b/pi-staking/apps/backend/app/Models/LedgerEntry.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class LedgerEntry extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'user_id',
+        'account',
+        'delta',
+        'currency',
+        'reference_type',
+        'reference_id',
+        'meta',
+        'occurred_at',
+    ];
+
+    protected $casts = [
+        'delta' => 'decimal:8',
+        'meta' => 'array',
+        'occurred_at' => 'datetime',
+    ];
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/pi-staking/apps/backend/app/Services/ClaimService.php
+++ b/pi-staking/apps/backend/app/Services/ClaimService.php
@@ -6,155 +6,136 @@ use App\Models\Claim;
 use App\Models\Investment;
 use App\Models\User;
 use App\Models\Transaction;
+use App\Support\Money;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Database\QueryException;
 use Exception;
 
 class ClaimService
 {
-    /**
-     * Effectuer un claim pour un investissement
-     */
-    public function processClaim(User $user, Investment $investment): Claim
+    public function __construct(private LedgerService $ledgerService)
     {
-        return DB::transaction(function () use ($user, $investment) {
-            // Validations
-            $this->validateClaim($user, $investment);
+    }
 
-            // Calculer le montant du claim
-            $amount = $this->calculateClaimAmount($investment);
+    public function processClaim(User $user, Investment $investment, ?string $forDate = null): Claim
+    {
+        $forDate = $forDate ?: now()->toDateString();
+        $lock = Cache::lock('claim:investment:' . $investment->id, 10);
 
-            // Créer le claim
-            $claim = $this->createClaimRecord($user, $investment, $amount);
+        return $lock->block(5, function () use ($user, $investment, $forDate) {
+            return DB::transaction(function () use ($user, $investment, $forDate) {
+                $investment = Investment::where('id', $investment->id)->lockForUpdate()->firstOrFail();
 
-            // Créditer les soldes claimables (pas le solde disponible)
-            if ($investment->source === 'bonus') {
-                $user->increment('claimable_bonus_balance', $amount);
-            } else {
-                $user->increment('claimable_balance', $amount);
-            }
-            $user->increment('total_claimed', $amount);
-            if (\Illuminate\Support\Facades\Schema::hasColumn('users', 'total_earned')) {
-                $user->increment('total_earned', $amount);
-            }
+                $this->validateClaim($user, $investment, $forDate);
 
-            // Mettre à jour l'investissement
-            $this->updateInvestmentAfterClaim($investment, $amount);
+                $baseAmount = Money::mul($investment->amount, $investment->daily_rate);
+                $amount = Money::mul($baseAmount, $investment->bonus_multiplier);
+                $amount = Money::round($amount);
+                $bonusAmount = Money::sub($amount, $baseAmount);
 
-            // Créer la transaction
-            $this->createClaimTransaction($user, $claim, $amount);
+                try {
+                    $claim = Claim::firstOrCreate([
+                        'investment_id' => $investment->id,
+                        'user_id' => $user->id,
+                        'claimed_for_day' => $forDate,
+                    ], [
+                        'base_amount' => $baseAmount,
+                        'bonus_amount' => $bonusAmount,
+                        'final_amount' => $amount,
+                        'claimed_at' => now(),
+                        'status' => 'processed',
+                        'daily_rate_applied' => $investment->daily_rate,
+                        'calculation_details' => [
+                            'base_calculation' => $baseAmount,
+                            'bonus_multiplier' => $investment->bonus_multiplier,
+                            'final_amount' => $amount,
+                        ],
+                    ]);
+                } catch (QueryException $e) {
+                    $claim = Claim::where('investment_id', $investment->id)
+                        ->where('user_id', $user->id)
+                        ->where('claimed_for_day', $forDate)
+                        ->first();
+                    if ($claim) {
+                        return $claim;
+                    }
+                    throw $e;
+                }
 
-            return $claim;
+                if ($claim->wasRecentlyCreated) {
+                    if ($investment->source === 'bonus') {
+                        $user->increment('claimable_bonus_balance', (float) $amount);
+                    } else {
+                        $user->increment('claimable_balance', (float) $amount);
+                    }
+                    $user->increment('total_claimed', (float) $amount);
+                    if (\Illuminate\Support\Facades\Schema::hasColumn('users', 'total_earned')) {
+                        $user->increment('total_earned', (float) $amount);
+                    }
+
+                    $investment->update([
+                        'last_claim_at' => now(),
+                        'next_claim_at' => now()->addDay(),
+                        'total_claimed' => (float) $investment->total_claimed + (float) $amount,
+                        'claims_count' => (int) $investment->claims_count + 1,
+                    ]);
+
+                    Transaction::create([
+                        'user_id' => $user->id,
+                        'type' => 'claim',
+                        'category' => 'staking',
+                        'amount' => 0,
+                        'balance_before' => $user->balance_pi,
+                        'balance_after' => $user->balance_pi,
+                        'status' => 'completed',
+                        'investment_id' => $claim->investment_id,
+                        'claim_id' => $claim->id,
+                        'description' => 'Daily claim credited to claimable balance',
+                        'processed_at' => now(),
+                        'metadata' => [
+                            'credited_to' => $investment->source === 'bonus' ? 'claimable_bonus' : 'claimable',
+                            'amount' => (float) $amount,
+                        ],
+                    ]);
+
+                    if ($investment->source === 'bonus') {
+                        $this->ledgerService->moveExternalToUser($user->id, 'claimable_bonus', $amount, 'claim', (string) $claim->id, [
+                            'investment_id' => $investment->id,
+                        ]);
+                    } else {
+                        $this->ledgerService->moveExternalToUser($user->id, 'claimable', $amount, 'claim', (string) $claim->id, [
+                            'investment_id' => $investment->id,
+                        ]);
+                    }
+
+                    if ($investment->end_at && now()->isAfter($investment->end_at)) {
+                        $investment->update(['status' => 'completed']);
+                    }
+                }
+
+                return $claim;
+            });
         });
     }
 
-    /**
-     * Valider qu'un claim peut être effectué
-     */
-    private function validateClaim(User $user, Investment $investment): void
+    private function validateClaim(User $user, Investment $investment, ?string $forDate = null): void
     {
         if ($investment->user_id !== $user->id) {
             throw new Exception('Cet investissement ne vous appartient pas.');
         }
 
         if (!$investment->canClaim()) {
-            throw new Exception('Ce claim n\'est pas encore disponible.');
+            throw new Exception("Ce claim n'est pas encore disponible.");
         }
 
-        // Vérifier qu'il n'y a pas déjà un claim pour aujourd'hui
-        $existingClaim = $investment->claims()
-            ->where('claimed_for_day', now()->toDateString())
-            ->exists();
-
+        $date = $forDate ?: now()->toDateString();
+        $existingClaim = $investment->claims()->where('claimed_for_day', $date)->exists();
         if ($existingClaim) {
-            throw new Exception('Vous avez déjà claimé pour cet investissement aujourd\'hui.');
+            throw new Exception("Vous avez déjà claimé pour cet investissement aujourd'hui.");
         }
     }
 
-    /**
-     * Calculer le montant du claim
-     */
-    private function calculateClaimAmount(Investment $investment): float
-    {
-        $baseAmount = $investment->amount * $investment->daily_rate;
-        
-        // Appliquer le multiplicateur de bonus
-        $amount = $baseAmount * $investment->bonus_multiplier;
-
-        // Arrondir à 8 décimales
-        return round($amount, 8);
-    }
-
-    /**
-     * Créer l'enregistrement du claim
-     */
-    private function createClaimRecord(User $user, Investment $investment, float $amount): Claim
-    {
-        $baseAmount = $investment->amount * $investment->daily_rate;
-        $bonusAmount = $amount - $baseAmount;
-
-        return Claim::create([
-            'investment_id' => $investment->id,
-            'user_id' => $user->id,
-            'claimed_for_day' => now()->toDateString(),
-            'base_amount' => $baseAmount,
-            'bonus_amount' => $bonusAmount,
-            'final_amount' => $amount,
-            'claimed_at' => now(),
-            'status' => 'processed',
-            'daily_rate_applied' => $investment->daily_rate,
-            'calculation_details' => [
-                'base_calculation' => $baseAmount,
-                'bonus_multiplier' => $investment->bonus_multiplier,
-                'final_amount' => $amount,
-            ],
-        ]);
-    }
-
-    /**
-     * Mettre à jour l'investissement après le claim
-     */
-    private function updateInvestmentAfterClaim(Investment $investment, float $amount): void
-    {
-        $investment->update([
-            'last_claim_at' => now(),
-            'next_claim_at' => now()->addDay(),
-            'total_claimed' => $investment->total_claimed + $amount,
-            'claims_count' => $investment->claims_count + 1,
-        ]);
-
-        // Vérifier si l'investissement est terminé
-        if ($investment->end_at && now()->isAfter($investment->end_at)) {
-            $investment->update(['status' => 'completed']);
-        }
-    }
-
-    /**
-     * Créer la transaction de claim
-     */
-    private function createClaimTransaction(User $user, Claim $claim, float $amount): Transaction
-    {
-        return Transaction::create([
-            'user_id' => $user->id,
-            'type' => 'claim',
-            'category' => 'staking',
-            'amount' => 0,
-            'balance_before' => $user->balance_pi,
-            'balance_after' => $user->balance_pi,
-            'status' => 'completed',
-            'investment_id' => $claim->investment_id,
-            'claim_id' => $claim->id,
-            'description' => 'Daily claim credited to claimable balance',
-            'processed_at' => now(),
-            'metadata' => [
-                'credited_to' => $claim->investment->source === 'bonus' ? 'claimable_bonus' : 'claimable',
-                'amount' => $amount,
-            ],
-        ]);
-    }
-
-    /**
-     * Obtenir tous les investissements claimables pour un utilisateur
-     */
     public function getClaimableInvestments(User $user): array
     {
         return $user->investments()
@@ -172,18 +153,16 @@ class ClaimService
             ->toArray();
     }
 
-    /**
-     * Claim en masse pour tous les investissements claimables
-     */
-    public function claimAll(User $user): array
+    public function claimAll(User $user, ?string $forDate = null): array
     {
+        $forDate = $forDate ?: now()->toDateString();
         $claimableInvestments = $this->getClaimableInvestments($user);
         $claims = [];
         $errors = [];
 
         foreach ($claimableInvestments as $investment) {
             try {
-                $claims[] = $this->processClaim($user, $investment);
+                $claims[] = $this->processClaim($user, $investment, $forDate);
             } catch (Exception $e) {
                 $errors[] = [
                     'investment_id' => $investment->id,
@@ -199,9 +178,6 @@ class ClaimService
         ];
     }
 
-    /**
-     * Obtenir les statistiques de claim pour un utilisateur
-     */
     public function getUserClaimStats(User $user): array
     {
         $claimableInvestments = $this->getClaimableInvestments($user);
@@ -210,7 +186,9 @@ class ClaimService
         return [
             'claimable_count' => count($claimableInvestments),
             'potential_claim_amount' => collect($claimableInvestments)->sum(function ($investment) {
-                return $this->calculateClaimAmount($investment);
+                $base = Money::mul($investment->amount, $investment->daily_rate);
+                $amt = Money::mul($base, $investment->bonus_multiplier);
+                return (float) Money::round($amt);
             }),
             'todays_claims_count' => $todaysClaims->count(),
             'todays_claims_amount' => $todaysClaims->sum('final_amount'),

--- a/pi-staking/apps/backend/app/Services/DepositService.php
+++ b/pi-staking/apps/backend/app/Services/DepositService.php
@@ -13,6 +13,10 @@ use Exception;
 
 class DepositService
 {
+    public function __construct(private LedgerService $ledgerService)
+    {
+    }
+
     public function assignAddressForUser(User $user): array
     {
         return DB::transaction(function () use ($user) {
@@ -322,6 +326,11 @@ class DepositService
                 'transaction_hash' => $txHash,
                 'description' => 'Dépôt Pi confirmé',
                 'processed_at' => now(),
+            ]);
+
+            $this->ledgerService->moveExternalToUser($user->id, 'principal', $amountF, 'deposit', (string) $deposit->id, [
+                'address_id' => $addr->id,
+                'tx_hash' => $txHash,
             ]);
 
             Log::channel('daily')->info('Dépôt confirmé', [

--- a/pi-staking/apps/backend/app/Services/LedgerService.php
+++ b/pi-staking/apps/backend/app/Services/LedgerService.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\LedgerEntry;
+use App\Models\User;
+use App\Support\Money;
+use Illuminate\Support\Carbon;
+
+class LedgerService
+{
+    public function post(null|int|User $user, string $account, string|float|int $delta, string $referenceType, string|int $referenceId, array $meta = [], ?Carbon $occurredAt = null): LedgerEntry
+    {
+        $userId = $user instanceof User ? $user->id : $user;
+        return LedgerEntry::create([
+            'user_id' => $userId,
+            'account' => $account,
+            'delta' => Money::round($delta),
+            'currency' => 'PI',
+            'reference_type' => $referenceType,
+            'reference_id' => (string) $referenceId,
+            'meta' => $meta,
+            'occurred_at' => $occurredAt ?? now(),
+        ]);
+    }
+
+    public function move(null|int|User $fromUser, string $fromAccount, null|int|User $toUser, string $toAccount, string|float|int $amount, string $referenceType, string|int $referenceId, array $meta = [], ?Carbon $occurredAt = null): array
+    {
+        $amt = Money::round($amount);
+        $entries = [];
+        $entries[] = $this->post($fromUser, $fromAccount, Money::mul($amt, -1), $referenceType, $referenceId, array_merge($meta, ['side' => 'debit']), $occurredAt);
+        $entries[] = $this->post($toUser, $toAccount, $amt, $referenceType, $referenceId, array_merge($meta, ['side' => 'credit']), $occurredAt);
+        return $entries;
+    }
+
+    public function moveExternalToUser(int|User $toUser, string $toAccount, string|float|int $amount, string $referenceType, string|int $referenceId, array $meta = [], ?Carbon $occurredAt = null): array
+    {
+        return $this->move(null, 'external', $toUser, $toAccount, $amount, $referenceType, $referenceId, $meta, $occurredAt);
+    }
+
+    public function moveUserToExternal(int|User $fromUser, string $fromAccount, string|float|int $amount, string $referenceType, string|int $referenceId, array $meta = [], ?Carbon $occurredAt = null): array
+    {
+        return $this->move($fromUser, $fromAccount, null, 'external', $amount, $referenceType, $referenceId, $meta, $occurredAt);
+    }
+}

--- a/pi-staking/apps/backend/app/Services/StakingService.php
+++ b/pi-staking/apps/backend/app/Services/StakingService.php
@@ -17,7 +17,8 @@ class StakingService
     public function __construct(
         private UserLevelService $userLevelService,
         private GamificationService $gamificationService,
-        private ReferralService $referralService
+        private ReferralService $referralService,
+        private LedgerService $ledgerService
     ) {}
 
     /**
@@ -41,6 +42,19 @@ class StakingService
 
             // Créer l'investissement
             $investment = $this->createInvestmentRecord($user, $package, $amount, $origin);
+
+            // Ledger: mouvement du portefeuille vers l'externe
+            $accountMap = [
+                'funds' => 'principal',
+                'bonus' => 'bonus',
+                'claimable' => 'claimable',
+                'claimable_bonus' => 'claimable_bonus',
+            ];
+            $acc = $accountMap[$source] ?? 'principal';
+            $this->ledgerService->moveUserToExternal($user->id, $acc, $amount, 'investment', (string) $investment->id, [
+                'package_id' => $package->id,
+                'source' => $source,
+            ]);
 
             // Créer la transaction
             $this->createInvestmentTransaction($user, $investment, $amount, $source);

--- a/pi-staking/apps/backend/app/Support/Money.php
+++ b/pi-staking/apps/backend/app/Support/Money.php
@@ -4,8 +4,197 @@ namespace App\Support;
 
 class Money
 {
-    public static function formatPi(float $amount, int $decimals = 8): string
+    public static function add(string|float|int $a, string|float|int $b, ?int $scale = null): string
     {
-        return number_format($amount, $decimals) . ' Pi';
+        $s = $scale ?? self::calcScale();
+        return bcadd(self::toStr($a), self::toStr($b), $s);
+    }
+
+    public static function sub(string|float|int $a, string|float|int $b, ?int $scale = null): string
+    {
+        $s = $scale ?? self::calcScale();
+        return bcsub(self::toStr($a), self::toStr($b), $s);
+    }
+
+    public static function mul(string|float|int $a, string|float|int $b, ?int $scale = null): string
+    {
+        $s = $scale ?? self::calcScale();
+        return bcmul(self::toStr($a), self::toStr($b), $s);
+    }
+
+    public static function div(string|float|int $a, string|float|int $b, ?int $scale = null): string
+    {
+        $s = $scale ?? self::calcScale();
+        return bcdiv(self::toStr($a), self::toStr($b), $s);
+    }
+
+    public static function cmp(string|float|int $a, string|float|int $b, ?int $scale = null): int
+    {
+        $s = $scale ?? self::calcScale();
+        return bccomp(self::toStr($a), self::toStr($b), $s);
+    }
+
+    public static function round(string|float|int $value, ?int $scale = null, ?string $mode = null): string
+    {
+        $scale = $scale ?? self::scale();
+        $mode = $mode ?? self::roundingMode();
+
+        $str = self::toStr($value);
+        $neg = str_starts_with($str, '-');
+        if ($neg) {
+            $str = substr($str, 1);
+        }
+
+        if (!str_contains($str, '.')) {
+            $str .= '.0';
+        }
+
+        $normalized = bcadd($str, '0', $scale + 5);
+        [$intPart, $fracPart] = explode('.', $normalized, 2);
+        $fracPart = str_pad($fracPart, $scale + 5, '0');
+
+        $keep = substr($fracPart, 0, $scale);
+        $rest = substr($fracPart, $scale); // guard + more
+        $guard = $rest[0] ?? '0';
+        $remainderBeyondGuard = substr($rest, 1);
+        $hasMoreNonZero = (bool) preg_match('/[1-9]/', $remainderBeyondGuard);
+
+        $resultInt = $intPart;
+        $resultFrac = $keep;
+
+        if ($mode === 'floor') {
+            if ($neg && (intval($fracPart) > 0)) {
+                [$resultInt, $resultFrac] = self::decimalDecrement($intPart, $keep, $scale);
+            }
+        } else {
+            $roundUp = false;
+            if ($mode === 'half_up') {
+                $roundUp = ((int)$guard >= 5);
+            } elseif ($mode === 'half_even') {
+                if ((int)$guard > 5) {
+                    $roundUp = true;
+                } elseif ((int)$guard < 5) {
+                    $roundUp = false;
+                } else { // guard == 5
+                    if ($hasMoreNonZero) {
+                        $roundUp = true; // > .5
+                    } else {
+                        // tie exactly .5 -> round to even
+                        $lastKept = $keep === '' ? '0' : substr($keep, -1);
+                        $roundUp = ((int)$lastKept % 2 === 1);
+                    }
+                }
+            } else { // default to half_even
+                if ((int)$guard > 5) {
+                    $roundUp = true;
+                } elseif ((int)$guard < 5) {
+                    $roundUp = false;
+                } else {
+                    if ($hasMoreNonZero) {
+                        $roundUp = true;
+                    } else {
+                        $lastKept = $keep === '' ? '0' : substr($keep, -1);
+                        $roundUp = ((int)$lastKept % 2 === 1);
+                    }
+                }
+            }
+
+            if ($roundUp && ($guard !== '0' || $hasMoreNonZero)) {
+                [$resultInt, $resultFrac] = self::decimalIncrement($intPart, $keep, $scale);
+            }
+        }
+
+        $out = $resultInt . ($scale > 0 ? ('.' . str_pad($resultFrac, $scale, '0')) : '');
+        if ($neg && $out !== '0' . ($scale > 0 ? '.' . str_repeat('0', $scale) : '')) {
+            $out = '-' . $out;
+        }
+        return $out;
+    }
+
+    public static function formatPi(string|float|int $amount, ?int $decimals = null): string
+    {
+        $decimals = $decimals ?? self::scale();
+        $rounded = self::round($amount, $decimals);
+        $float = (float) $rounded; // for number_format grouping consistency
+        return number_format($float, $decimals) . ' Pi';
+    }
+
+    public static function scale(): int
+    {
+        return (int) (config('finance.scale', 8));
+    }
+
+    private static function calcScale(): int
+    {
+        // Use a few extra digits during intermediate calculations
+        return self::scale() + 4;
+    }
+
+    private static function roundingMode(): string
+    {
+        $mode = config('finance.rounding_mode', 'half_even');
+        return in_array($mode, ['half_even', 'half_up', 'floor'], true) ? $mode : 'half_even';
+    }
+
+    private static function toStr(string|float|int $v): string
+    {
+        if (is_string($v)) {
+            return $v;
+        }
+        if (is_int($v)) {
+            return (string) $v;
+        }
+        return rtrim(rtrim(sprintf('%.20F', $v), '0'), '.');
+    }
+
+    private static function decimalIncrement(string $intPart, string $fracPart, int $scale): array
+    {
+        if ($scale === 0) {
+            $int = (string) ((int) $intPart + 1);
+            return [$int, ''];
+        }
+        $frac = $fracPart;
+        $carry = 1;
+        for ($i = $scale - 1; $i >= 0; $i--) {
+            $d = (int) ($frac[$i] ?? '0') + $carry;
+            if ($d >= 10) {
+                $frac[$i] = '0';
+                $carry = 1;
+            } else {
+                $frac[$i] = (string) $d;
+                $carry = 0;
+                break;
+            }
+        }
+        if ($carry === 1) {
+            $intPart = (string) ((int) $intPart + 1);
+        }
+        return [$intPart, $frac];
+    }
+
+    private static function decimalDecrement(string $intPart, string $fracPart, int $scale): array
+    {
+        if ($scale === 0) {
+            $int = (string) ((int) $intPart - 1);
+            return [$int, ''];
+        }
+        $frac = $fracPart;
+        $borrow = 1;
+        for ($i = $scale - 1; $i >= 0; $i--) {
+            $d = (int) ($frac[$i] ?? '0') - $borrow;
+            if ($d < 0) {
+                $frac[$i] = '9';
+                $borrow = 1;
+            } else {
+                $frac[$i] = (string) $d;
+                $borrow = 0;
+                break;
+            }
+        }
+        if ($borrow === 1) {
+            $intPart = (string) ((int) $intPart - 1);
+            $frac = str_repeat('9', $scale);
+        }
+        return [$intPart, $frac];
     }
 }

--- a/pi-staking/apps/backend/config/finance.php
+++ b/pi-staking/apps/backend/config/finance.php
@@ -1,0 +1,6 @@
+<?php
+
+return [
+    'rounding_mode' => env('FINANCE_ROUNDING_MODE', 'half_even'),
+    'scale' => (int) env('FINANCE_SCALE', 8),
+];

--- a/pi-staking/apps/backend/database/migrations/2025_09_16_100000_create_ledger_entries_table.php
+++ b/pi-staking/apps/backend/database/migrations/2025_09_16_100000_create_ledger_entries_table.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('ledger_entries', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->nullable()->constrained('users')->nullOnDelete();
+            $table->enum('account', [
+                'principal',
+                'bonus',
+                'claimable',
+                'claimable_bonus',
+                'pending_withdrawal',
+                'fees',
+                'external',
+            ]);
+            $table->decimal('delta', 24, 8);
+            $table->string('currency', 10)->default('PI');
+            $table->string('reference_type');
+            $table->string('reference_id');
+            $table->json('meta')->nullable();
+            $table->timestamp('occurred_at');
+            $table->timestamps();
+
+            $table->index(['user_id', 'occurred_at']);
+            $table->index(['reference_type', 'reference_id']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('ledger_entries');
+    }
+};

--- a/pi-staking/apps/backend/tests/Feature/ClaimIdempotenceTest.php
+++ b/pi-staking/apps/backend/tests/Feature/ClaimIdempotenceTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Claim;
+use App\Models\Investment;
+use App\Models\StakingPackage;
+use App\Models\User;
+use App\Services\ClaimService;
+use Illuminate\Support\Facades\Artisan;
+use Tests\TestCase;
+
+class ClaimIdempotenceTest extends TestCase
+{
+    public function test_double_claim_same_day_is_prevented(): void
+    {
+        $user = User::factory()->create();
+        $package = StakingPackage::create([
+            'name' => 'Bronze',
+            'daily_rate' => 0.001,
+            'min_amount' => 10,
+            'max_amount' => null,
+            'duration_days' => 365,
+            'level' => 'bronze',
+            'is_active' => true,
+            'is_discovery_bonus' => false,
+            'features' => [],
+            'sort_order' => 1,
+        ]);
+
+        $investment = Investment::create([
+            'user_id' => $user->id,
+            'staking_package_id' => $package->id,
+            'amount' => 100,
+            'daily_rate' => 0.001,
+            'start_at' => now()->subDay(),
+            'end_at' => null,
+            'status' => 'active',
+            'source' => 'funds',
+            'next_claim_at' => now()->subMinute(),
+            'bonus_multiplier' => 1.0,
+            'claims_count' => 0,
+            'total_claimed' => 0,
+        ]);
+
+        $service = app(ClaimService::class);
+        $date = now()->toDateString();
+
+        $claim1 = $service->processClaim($user, $investment, $date);
+        $claim2 = $service->processClaim($user, $investment, $date);
+
+        $this->assertInstanceOf(Claim::class, $claim1);
+        $this->assertInstanceOf(Claim::class, $claim2);
+
+        $this->assertEquals(1, Claim::where('investment_id', $investment->id)->where('claimed_for_day', $date)->count());
+
+        $expected = round(100 * 0.001, 8);
+        $user->refresh();
+        $this->assertEquals($expected, (float) $user->claimable_balance);
+    }
+}

--- a/pi-staking/apps/backend/tests/Feature/LedgerTest.php
+++ b/pi-staking/apps/backend/tests/Feature/LedgerTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Investment;
+use App\Models\LedgerEntry;
+use App\Models\StakingPackage;
+use App\Models\User;
+use App\Services\ClaimService;
+use App\Services\LedgerService;
+use Tests\TestCase;
+
+class LedgerTest extends TestCase
+{
+    public function test_double_entry_sum_zero(): void
+    {
+        $user = User::factory()->create();
+        $ledger = app(LedgerService::class);
+        $refId = 'REF-TEST-1';
+
+        $ledger->moveExternalToUser($user->id, 'principal', 100, 'test_tx', $refId);
+
+        $sum = LedgerEntry::where('reference_type', 'test_tx')->where('reference_id', $refId)->sum('delta');
+        $this->assertEquals(0.0, (float) $sum);
+    }
+
+    public function test_claim_posting_is_balanced(): void
+    {
+        $user = User::factory()->create();
+        $pkg = StakingPackage::create([
+            'name' => 'Bronze',
+            'daily_rate' => 0.001,
+            'min_amount' => 10,
+            'max_amount' => null,
+            'duration_days' => 365,
+            'level' => 'bronze',
+            'is_active' => true,
+            'is_discovery_bonus' => false,
+            'features' => [],
+            'sort_order' => 1,
+        ]);
+        $inv = Investment::create([
+            'user_id' => $user->id,
+            'staking_package_id' => $pkg->id,
+            'amount' => 100,
+            'daily_rate' => 0.001,
+            'start_at' => now()->subDay(),
+            'status' => 'active',
+            'source' => 'funds',
+            'next_claim_at' => now()->subMinute(),
+            'bonus_multiplier' => 1.0,
+            'claims_count' => 0,
+            'total_claimed' => 0,
+        ]);
+
+        $claim = app(ClaimService::class)->processClaim($user, $inv, now()->toDateString());
+
+        $sum = LedgerEntry::where('reference_type', 'claim')->where('reference_id', (string) $claim->id)->sum('delta');
+        $this->assertEquals(0.0, (float) $sum);
+    }
+}

--- a/pi-staking/apps/backend/tests/Feature/ReconcileUsersCommandTest.php
+++ b/pi-staking/apps/backend/tests/Feature/ReconcileUsersCommandTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Investment;
+use App\Models\StakingPackage;
+use App\Models\User;
+use App\Services\ClaimService;
+use App\Services\LedgerService;
+use Illuminate\Support\Facades\Artisan;
+use Tests\TestCase;
+
+class ReconcileUsersCommandTest extends TestCase
+{
+    public function test_reconcile_reports_no_diff_after_standard_ops(): void
+    {
+        $user = User::factory()->create();
+        $ledger = app(LedgerService::class);
+
+        $ledger->moveExternalToUser($user->id, 'principal', 120, 'deposit', 'D1');
+        $user->increment('balance_pi', 120);
+
+        $pkg = StakingPackage::create([
+            'name' => 'Bronze',
+            'daily_rate' => 0.001,
+            'min_amount' => 10,
+            'max_amount' => null,
+            'duration_days' => 365,
+            'level' => 'bronze',
+            'is_active' => true,
+            'is_discovery_bonus' => false,
+            'features' => [],
+            'sort_order' => 1,
+        ]);
+        $inv = app(\App\Services\StakingService::class)->createInvestment($user, $pkg, 50, 'funds');
+
+        $claim = app(ClaimService::class)->processClaim($user, $inv, now()->toDateString());
+
+        $ledger->move($user->id, 'principal', $user->id, 'pending_withdrawal', 10, 'withdrawal_request', 'W1');
+        $user->increment('pending_withdrawal', 10);
+
+        Artisan::call('finance:reconcile-users --dry-run');
+        $output = Artisan::output();
+        $this->assertStringContainsString('Aucun écart', $output);
+    }
+}

--- a/pi-staking/apps/backend/tests/Unit/MoneyTest.php
+++ b/pi-staking/apps/backend/tests/Unit/MoneyTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Support\Money;
+use Tests\TestCase;
+
+class MoneyTest extends TestCase
+{
+    public function test_round_half_even_ties(): void
+    {
+        $this->assertSame('1.00', Money::round('1.005', 2, 'half_even'));
+        $this->assertSame('1.02', Money::round('1.015', 2, 'half_even'));
+        $this->assertSame('2.00', Money::round('1.995', 2, 'half_even'));
+        $this->assertSame('-1.00', Money::round('-1.005', 2, 'half_even'));
+    }
+
+    public function test_add_mul_div(): void
+    {
+        $sum = Money::add('0.1', '0.2');
+        $this->assertSame('0.3000', substr($sum, 0, 6));
+
+        $mul = Money::mul('1.23456789', '2');
+        $this->assertSame('2.46913578', substr($mul, 0, 11));
+
+        $div = Money::div('1', '3');
+        $this->assertTrue(str_starts_with($div, '0.3333'));
+    }
+}


### PR DESCRIPTION
Objective: financial correctness, idempotence, and global reconciliation.

Scope delivered:
- Idempotence & concurrency for claims: DB uniqueness, application idempotence (firstOrCreate), transaction + lockForUpdate on Investment, cache lock per investment (short TTL), daily processing chunked with per-investment locks.
- Centralized rounding policy: config/finance.php (rounding_mode=half_even|half_up|floor, scale=8); Money BCMath wrappers used across Claim/Investment/Deposit/Withdrawal calculations.
- Double-entry ledger: ledger_entries schema + LedgerService (post/move/external helpers). Integrated with Deposit (external->principal), Staking (principal|bonus|claimable|claimable_bonus->external), Claim (external->claimable or claimable_bonus), Withdrawals (principal->pending_withdrawal, pending_withdrawal->external, rejection/annulation: pending_withdrawal->principal).
- Reconciliation: artisan finance:reconcile-users --dry-run to rebuild balances from ledger and compare with users.* columns; report discrepancies.
- Tests: Money rounding/ops, claim idempotence (simulated double claim same day), ledger invariants (sum zero per transaction), reconcile command (no diffs under standard flows).

Acceptance criteria addressed:
- Duplicate claim prevented by DB and app logic.
- All monetary calcs use centralized rounding; tests pass.
- Every relevant financial operation posts balanced ledger entries.
- Reconciliation reconstructs user balances; reports empty under normal scenarios.
- README FinOps section documents rounding policy and ledger usage.

Migration notes:
- Run: php artisan migrate
- Ensure cache store supports locks (Redis recommended) for claim concurrency.

Test plan:
- php artisan test --filter=MoneyTest
- php artisan test --filter=ClaimIdempotenceTest
- php artisan test --filter=LedgerTest
- php artisan test --filter=ReconcileUsersCommandTest


₍ᐢ•(ܫ)•ᐢ₎ Generated by [Capy](https://capy.ai) ([view task](https://capy.ai/project/57292b1c-84af-11f0-a94e-3eef481a796b/task/5a8940e4-aa54-424c-83cb-207a340b0b67))