### PR TITLE
UX claims & reinvest: bulk-claim atomique + reinvest-quick (idempotence + Pi)

### DIFF
--- a/pi-staking/apps/backend/app/Http/Controllers/ClaimController.php
+++ b/pi-staking/apps/backend/app/Http/Controllers/ClaimController.php
@@ -8,6 +8,8 @@ use App\Services\ClaimService;
 use Illuminate\Http\Request;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Validator;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
 
 class ClaimController extends Controller
 {
@@ -93,6 +95,135 @@ class ClaimController extends Controller
                 'success' => false,
                 'message' => 'Erreur lors du traitement : ' . $e->getMessage()
             ], 500);
+        }
+    }
+
+    /**
+     * Claim groupé atomique et idempotent
+     * Body: { investment_ids: number[], idempotency_key: string }
+     */
+    public function bulkClaim(Request $request): JsonResponse
+    {
+        $validator = Validator::make($request->all(), [
+            'investment_ids' => 'required|array|min:1',
+            'investment_ids.*' => 'integer',
+            'idempotency_key' => 'required|string|min:6|max:100',
+        ], [
+            'investment_ids.required' => 'La liste des investissements est requise.',
+            'investment_ids.min' => 'Au moins un investissement est requis.',
+            'idempotency_key.required' => "La clé d'idempotence est requise.",
+        ]);
+
+        if ($validator->fails()) {
+            return response()->json([
+                'success' => false,
+                'message' => 'Erreurs de validation',
+                'errors' => $validator->errors(),
+            ], 422);
+        }
+
+        $user = $request->user();
+        $ids = array_unique(array_map('intval', $request->input('investment_ids', [])));
+        sort($ids);
+        $idempotencyKey = (string) $request->input('idempotency_key');
+
+        // Retour idempotent si déjà traité
+        $cacheKey = 'idempo:bulk_claim:' . $user->id . ':' . $idempotencyKey;
+        if (Cache::has($cacheKey)) {
+            $cached = Cache::get($cacheKey);
+            return response()->json($cached);
+        }
+
+        // Prévalidation: appartenances + éligibilité
+        $investments = $user->investments()->whereIn('id', $ids)->get();
+        $notFound = array_values(array_diff($ids, $investments->pluck('id')->toArray()));
+        if (!empty($notFound)) {
+            $resp = [
+                'success' => false,
+                'message' => 'Certains investissements sont introuvables.',
+                'data' => [
+                    'missing_investment_ids' => $notFound,
+                ],
+            ];
+            // Ne pas mettre en cache les erreurs de validation d’entrée
+            return response()->json($resp, 404);
+        }
+
+        // Vérifier qu'ils sont tous claimables maintenant pour éviter demi-traitements
+        $precheckErrors = [];
+        foreach ($investments as $inv) {
+            if (!$inv->canClaim()) {
+                $precheckErrors[] = [
+                    'investment_id' => $inv->id,
+                    'error' => "Non éligible au claim pour le moment",
+                ];
+            }
+        }
+        if (!empty($precheckErrors)) {
+            $resp = [
+                'success' => false,
+                'message' => 'Aucun changement effectué: des investissements ne sont pas éligibles.',
+                'data' => [
+                    'errors' => $precheckErrors,
+                    'eligible_count' => count($investments) - count($precheckErrors),
+                ],
+            ];
+            // Idempotence: on peut mettre en cache un résultat d’échec logique court
+            Cache::put($cacheKey, $resp, now()->addMinutes(30));
+            return response()->json($resp, 422);
+        }
+
+        // Traitement atomique sous transaction
+        try {
+            $result = DB::transaction(function () use ($user, $investments) {
+                $details = [];
+                $total = 0.0;
+
+                foreach ($investments as $inv) {
+                    // L’idempotence par jour est aussi assurée au niveau du service
+                    $claim = $this->claimService->processClaim($user, $inv);
+                    $amount = (float) $claim->final_amount;
+                    $details[] = [
+                        'investment_id' => $inv->id,
+                        'status' => 'success',
+                        'amount' => $amount,
+                        'claim_id' => $claim->id,
+                        'claimed_for_day' => $claim->claimed_for_day?->toDateString(),
+                    ];
+                    $total += $amount;
+                }
+
+                return [
+                    'details' => $details,
+                    'total' => round($total, 8),
+                ];
+            });
+
+            $response = [
+                'success' => true,
+                'message' => sprintf('Réclamation groupée réussie: %d élément(s), total %.8f Pi', count($result['details']), $result['total']),
+                'data' => [
+                    'total_claimed' => $result['total'],
+                    'claims' => $result['details'],
+                    'idempotency_key' => $idempotencyKey,
+                    'user' => $user->fresh(),
+                ],
+            ];
+            // Mettre en cache le résultat pour idempotence (TTL 6h)
+            Cache::put($cacheKey, $response, now()->addHours(6));
+
+            return response()->json($response);
+        } catch (\Throwable $e) {
+            $resp = [
+                'success' => false,
+                'message' => 'Échec de la réclamation groupée: ' . $e->getMessage(),
+                'data' => [
+                    'idempotency_key' => $idempotencyKey,
+                ],
+            ];
+            // Mettre un cache court pour éviter retry flood immédiat
+            Cache::put($cacheKey, $resp, now()->addMinutes(5));
+            return response()->json($resp, 422);
         }
     }
 

--- a/pi-staking/apps/backend/app/Http/Controllers/StakingController.php
+++ b/pi-staking/apps/backend/app/Http/Controllers/StakingController.php
@@ -210,6 +210,75 @@ class StakingController extends Controller
     }
 
     /**
+     * Réinvestissement rapide depuis claimable_balance vers un package éligible
+     */
+    public function reinvestQuick(Request $request): JsonResponse
+    {
+        $user = $request->user();
+
+        $balance = (float) ($user->claimable_balance ?? 0);
+        if ($balance <= 0) {
+            return response()->json([
+                'success' => false,
+                'message' => 'Aucun gain réinvestissable disponible.'
+            ], 422);
+        }
+
+        // Trouver un package régulier actif disponible pour l'utilisateur, trié par min_amount croissant
+        $candidate = StakingPackage::active()
+            ->regular()
+            ->orderBy('min_amount')
+            ->get()
+            ->first(function ($pkg) use ($user, $balance) {
+                return $pkg->canBeUsedBy($user) && (float) $pkg->min_amount <= $balance;
+            });
+
+        if (!$candidate) {
+            // Trouver le plus petit min_amount éligible pour un message clair
+            $smallest = StakingPackage::active()->regular()->orderBy('min_amount')->get()
+                ->first(fn($pkg) => $pkg->canBeUsedBy($user));
+
+            $minTxt = $smallest ? (string) $smallest->min_amount : '—';
+            return response()->json([
+                'success' => false,
+                'message' => $smallest
+                    ? "Votre solde réinvestissable est inférieur au minimum requis (min {$minTxt} Pi)."
+                    : "Aucun package éligible disponible pour votre niveau."
+            ], 422);
+        }
+
+        // Montant à réinvestir: tout le solde claimable, borné par max_amount du package si présent
+        $amount = $balance;
+        if (!empty($candidate->max_amount) && (float) $candidate->max_amount > 0) {
+            $amount = min($amount, (float) $candidate->max_amount);
+        }
+
+        try {
+            $investment = \DB::transaction(function () use ($user, $candidate, $amount) {
+                return $this->stakingService->createInvestment($user, $candidate, (float) $amount, 'claimable')->load('stakingPackage');
+            });
+
+            $user->refresh();
+
+            return response()->json([
+                'success' => true,
+                'message' => 'Réinvestissement rapide effectué avec succès',
+                'data' => [
+                    'investment' => $investment,
+                    'reinvested_amount' => (float) $amount,
+                    'remaining_claimable' => (float) $user->claimable_balance,
+                    'package' => $investment->stakingPackage,
+                ],
+            ], 201);
+        } catch (\Throwable $e) {
+            return response()->json([
+                'success' => false,
+                'message' => $e->getMessage(),
+            ], 422);
+        }
+    }
+
+    /**
      * Réinvestir le bonus de bienvenue dans le package Discovery
      */
     public function reinvestBonus(Request $request): JsonResponse

--- a/pi-staking/apps/backend/routes/api.php
+++ b/pi-staking/apps/backend/routes/api.php
@@ -67,6 +67,7 @@ Route::middleware('auth:sanctum')->group(function () {
         Route::get('/performance', [StakingController::class, 'getPerformanceHistory']);
         Route::post('/reinvest-bonus', [StakingController::class, 'reinvestBonus']);
         Route::post('/reinvest', [StakingController::class, 'reinvest']);
+        Route::post('/reinvest-quick', [StakingController::class, 'reinvestQuick']);
     });
 
     // Gestion des réclamations

--- a/pi-staking/apps/backend/tests/Feature/BulkClaimApiTest.php
+++ b/pi-staking/apps/backend/tests/Feature/BulkClaimApiTest.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use App\Models\Investment;
+use App\Models\StakingPackage;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class BulkClaimApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        \Spatie\Permission\Models\Role::findOrCreate('admin');
+    }
+
+    public function test_bulk_claim_success_and_idempotence(): void
+    {
+        $user = User::factory()->create(['claimable_balance' => 0]);
+
+        $pkg = StakingPackage::create([
+            'name' => 'Bronze',
+            'description' => 'Std',
+            'daily_rate' => 0.01,
+            'min_amount' => 10,
+            'max_amount' => 100000,
+            'duration_days' => 30,
+            'max_duration_days' => 30,
+            'level' => 'bronze',
+            'is_active' => true,
+            'is_discovery_bonus' => false,
+            'max_concurrent' => 10,
+            'features' => [],
+            'sort_order' => 1,
+        ]);
+
+        // Two active investments eligible to claim now
+        $inv1 = Investment::create([
+            'user_id' => $user->id,
+            'staking_package_id' => $pkg->id,
+            'amount' => 50,
+            'daily_rate' => 0.01,
+            'start_at' => now()->subDay(),
+            'status' => 'active',
+            'source' => 'funds',
+            'next_claim_at' => now()->subMinute(),
+            'bonus_multiplier' => 1.0,
+            'claims_count' => 0,
+            'total_claimed' => 0,
+        ]);
+        $inv2 = Investment::create([
+            'user_id' => $user->id,
+            'staking_package_id' => $pkg->id,
+            'amount' => 100,
+            'daily_rate' => 0.01,
+            'start_at' => now()->subDay(),
+            'status' => 'active',
+            'source' => 'funds',
+            'next_claim_at' => now()->subMinute(),
+            'bonus_multiplier' => 1.0,
+            'claims_count' => 0,
+            'total_claimed' => 0,
+        ]);
+
+        $ids = [$inv1->id, $inv2->id];
+        $key = 'test-key-'.uniqid();
+
+        $res = $this->actingAs($user, 'sanctum')
+            ->postJson('/api/claims/bulk-claim', [
+                'investment_ids' => $ids,
+                'idempotency_key' => $key,
+            ]);
+        $res->assertOk()->assertJson(['success' => true]);
+        $total = $res->json('data.total_claimed');
+        $this->assertGreaterThan(0, $total);
+
+        $before = $total;
+
+        // Idempotent second call (same key) must return same total and not double-credit
+        $res2 = $this->actingAs($user, 'sanctum')
+            ->postJson('/api/claims/bulk-claim', [
+                'investment_ids' => array_reverse($ids),
+                'idempotency_key' => $key,
+            ]);
+        $res2->assertOk()->assertJson(['success' => true]);
+        $this->assertEquals($before, $res2->json('data.total_claimed'));
+
+        $user->refresh();
+        $this->assertEquals($before, (float) $user->claimable_balance);
+    }
+
+    public function test_bulk_claim_rejects_when_not_claimable(): void
+    {
+        $user = User::factory()->create();
+        $pkg = StakingPackage::create([
+            'name' => 'Bronze',
+            'daily_rate' => 0.01,
+            'min_amount' => 10,
+            'max_amount' => 100000,
+            'duration_days' => 30,
+            'max_duration_days' => 30,
+            'level' => 'bronze',
+            'is_active' => true,
+            'is_discovery_bonus' => false,
+            'features' => [],
+            'sort_order' => 1,
+        ]);
+        $inv = Investment::create([
+            'user_id' => $user->id,
+            'staking_package_id' => $pkg->id,
+            'amount' => 50,
+            'daily_rate' => 0.01,
+            'start_at' => now(),
+            'status' => 'active',
+            'source' => 'funds',
+            'next_claim_at' => now()->addHour(),
+            'bonus_multiplier' => 1.0,
+            'claims_count' => 0,
+            'total_claimed' => 0,
+        ]);
+
+        $res = $this->actingAs($user, 'sanctum')
+            ->postJson('/api/claims/bulk-claim', [
+                'investment_ids' => [$inv->id],
+                'idempotency_key' => 'k-'.uniqid(),
+            ]);
+        $res->assertStatus(422)->assertJson(['success' => false]);
+        $this->assertEquals(0.0, (float) $user->fresh()->claimable_balance);
+    }
+}

--- a/pi-staking/apps/backend/tests/Feature/ReinvestQuickApiTest.php
+++ b/pi-staking/apps/backend/tests/Feature/ReinvestQuickApiTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use App\Models\Investment;
+use App\Models\StakingPackage;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ReinvestQuickApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_reinvest_quick_requires_balance(): void
+    {
+        $user = User::factory()->create(['claimable_balance' => 0]);
+        $res = $this->actingAs($user, 'sanctum')->postJson('/api/staking/reinvest-quick');
+        $res->assertStatus(422)->assertJson(['success' => false]);
+    }
+
+    public function test_reinvest_quick_invests_from_claimable(): void
+    {
+        $user = User::factory()->create(['claimable_balance' => 25]);
+
+        $pkg = StakingPackage::create([
+            'name' => 'Bronze',
+            'description' => 'Std',
+            'daily_rate' => 0.01,
+            'min_amount' => 10,
+            'max_amount' => 100000,
+            'duration_days' => 30,
+            'max_duration_days' => 30,
+            'level' => 'bronze',
+            'is_active' => true,
+            'is_discovery_bonus' => false,
+            'max_concurrent' => 10,
+            'features' => [],
+            'sort_order' => 1,
+        ]);
+
+        $res = $this->actingAs($user, 'sanctum')->postJson('/api/staking/reinvest-quick');
+        $res->assertCreated()->assertJson(['success' => true]);
+        $user->refresh();
+        $this->assertEquals(0.0, (float) $user->claimable_balance);
+        $this->assertDatabaseCount('investments', 1);
+        /** @var Investment $inv */
+        $inv = Investment::first();
+        $this->assertEquals('funds', $inv->source); // origin mapped
+        $this->assertEquals(25.0, (float) $inv->amount);
+    }
+}

--- a/pi-staking/pi-staking-frontend/src/components/UserDashboardComplete.tsx
+++ b/pi-staking/pi-staking-frontend/src/components/UserDashboardComplete.tsx
@@ -218,14 +218,25 @@ export function UserDashboardComplete({ onLogout }: UserDashboardCompleteProps) 
     }
   };
 
+  const [claimAllLoading, setClaimAllLoading] = useState(false);
+  const [reinvestQuickLoading, setReinvestQuickLoading] = useState(false);
+
   const handleClaimAll = async () => {
-    if (!claimableInvestments?.length) return;
-    
+    if (!safeClaimableInvestments?.length) return;
     try {
-      await claimsService.bulkClaim();
+      setClaimAllLoading(true);
+      const ids = safeClaimableInvestments.map((c: any) => Number(c.investment_id || c.id)).filter(Boolean);
+      const res = await claimsService.bulkClaim(ids);
+      if (!res.success) {
+        window.alert(res.message || 'Échec de la réclamation en masse');
+      }
       await refreshAllData();
+      await refreshUser();
     } catch (error) {
       console.error('Erreur réclamation:', error);
+      window.alert('Erreur lors de la réclamation');
+    } finally {
+      setClaimAllLoading(false);
     }
   };
 
@@ -681,14 +692,51 @@ export function UserDashboardComplete({ onLogout }: UserDashboardCompleteProps) 
 
               <Button 
                 onClick={handleClaimAll}
-                disabled={!claimableInvestments?.length}
+                disabled={!safeClaimableInvestments?.length || claimAllLoading}
+                aria-busy={claimAllLoading}
                 className="h-16 bg-pi-gold hover:bg-pi-gold/90 text-white"
               >
                 <div className="flex flex-col items-center gap-2">
                   <Gift className="h-5 w-5" />
-                  <span>Réclamer Tout ({claimableInvestments?.length || 0})</span>
+                  <span>{claimAllLoading ? 'Réclamation...' : `Réclamer Tout (${safeClaimableInvestments?.length || 0})`}</span>
                 </div>
               </Button>
+
+              {(() => {
+                const cb = Number((user as any)?.claimable_balance || 0);
+                const eligible = [...regularPackages].sort((a:any,b:any)=>a.min_amount-b.min_amount).find((p:any)=> cb >= Number(p.min_amount));
+                return (
+                  <Button 
+                    onClick={async () => {
+                      try {
+                        setReinvestQuickLoading(true);
+                        const res = await stakingService.reinvestQuick();
+                        if (!res.success) {
+                          window.alert(res.message || 'Échec du réinvestissement rapide');
+                        } else {
+                          window.alert(`Réinvestissement rapide: ${formatCurrency(res.data?.reinvested_amount || 0)} Pi`);
+                        }
+                        await refreshAllData();
+                        await refreshUser();
+                      } catch (e) {
+                        console.error(e);
+                        window.alert('Erreur lors du réinvestissement rapide');
+                      } finally {
+                        setReinvestQuickLoading(false);
+                      }
+                    }}
+                    disabled={!eligible || reinvestQuickLoading}
+                    aria-busy={reinvestQuickLoading}
+                    variant="outline"
+                    className="h-16"
+                  >
+                    <div className="flex flex-col items-center gap-2">
+                      <TrendingUp className="h-5 w-5" />
+                      <span>{reinvestQuickLoading ? 'Réinvest. rapide...' : 'Réinvestissement rapide'}</span>
+                    </div>
+                  </Button>
+                );
+              })()}
 
               <Button 
                 onClick={() => setShowWithdrawModal(true)}
@@ -972,9 +1020,11 @@ export function UserDashboardComplete({ onLogout }: UserDashboardCompleteProps) 
                   <Button 
                     onClick={handleClaimAll}
                     className="bg-pi-gold hover:bg-pi-gold/90 text-white"
+                    disabled={claimAllLoading}
+                    aria-busy={claimAllLoading}
                   >
                     <Gift className="h-4 w-4 mr-2" />
-                    Tout Réclamer ({formatCurrency(totalClaimable)} Pi)
+                    {claimAllLoading ? 'Réclamation...' : `Tout Réclamer (${formatCurrency(totalClaimable)} Pi)`}
                   </Button>
                 )}
                 <Button onClick={() => refreshAllData()} variant="outline">
@@ -982,6 +1032,10 @@ export function UserDashboardComplete({ onLogout }: UserDashboardCompleteProps) 
                   Actualiser
                 </Button>
               </div>
+            </div>
+
+            <div className="text-xs text-muted-foreground">
+              Min retrait: 2 Pi • Caps/jour: Bronze 20, Silver 50, Gold 100, Diamond 200 Pi • Taux journaliers approx.: Discovery 2.5%, Bronze 0.8%, Silver 0.5%, Gold 0.3%, Diamond 0.2%
             </div>
 
             {/* Réclamations disponibles */}

--- a/pi-staking/pi-staking-frontend/src/services/claimsService.ts
+++ b/pi-staking/pi-staking-frontend/src/services/claimsService.ts
@@ -82,14 +82,36 @@ export interface BulkClaimResult {
 
 class ClaimsService {
   
-  // Récupérer tous les investissements réclamables
+  // Récupérer tous les investissements réclamables (normalisé)
   async getClaimableInvestments(): Promise<{ success: boolean; data: ClaimableInvestment[] }> {
     try {
       const response = await api.get('/claims/available');
-      return response.data;
+      const payload = response.data?.data || {};
+      const items = Array.isArray(payload.claimable_investments) ? payload.claimable_investments : [];
+      const mapped: ClaimableInvestment[] = items.map((it: any) => ({
+        id: String(it.investment_id),
+        investment_id: String(it.investment_id),
+        amount: Number(it.amount || 0),
+        claimable_amount: Number(it.next_claim_amount || 0),
+        last_claimed_at: null,
+        next_claim_at: it.next_claim_at,
+        can_claim: Boolean(it.can_claim_now),
+        daily_rate: 0,
+        days_since_last_claim: 0,
+        investment: {
+          id: String(it.investment_id),
+          amount: Number(it.amount || 0),
+          status: 'active',
+          package: {
+            name: it.package_name || 'Package',
+            level: 'bronze'
+          }
+        }
+      }));
+      return { success: true, data: mapped };
     } catch (error) {
       console.error('Erreur lors de la récupération des investissements réclamables:', error);
-      throw error;
+      return { success: false, data: [] };
     }
   }
 
@@ -146,14 +168,27 @@ class ClaimsService {
     }
   }
 
-  // Réclamation en masse de tous les investissements disponibles
-  async bulkClaim(): Promise<{ success: boolean; data: BulkClaimResult; message: string }> {
+  // Réclamation en masse (atomique + idempotente)
+  async bulkClaim(investmentIds?: number[]): Promise<{ success: boolean; data: any; message: string }> {
     try {
-      const response = await api.post('/claims/bulk-claim');
+      let ids = investmentIds;
+      if (!ids || !ids.length) {
+        const res = await this.getClaimableInvestments();
+        ids = res.success ? res.data.map((c) => Number(c.investment_id)) : [];
+      }
+      if (!ids || !ids.length) {
+        return { success: false, data: null, message: 'Aucun investissement éligible à réclamer' };
+      }
+      const idempotencyKey = `bulk-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+      const response = await api.post('/claims/bulk-claim', {
+        investment_ids: ids,
+        idempotency_key: idempotencyKey
+      });
       return response.data;
-    } catch (error) {
+    } catch (error: any) {
       console.error('Erreur lors de la réclamation en masse:', error);
-      throw error;
+      const message = error.response?.data?.message || 'Erreur de réclamation en masse';
+      return { success: false, data: null, message };
     }
   }
 

--- a/pi-staking/pi-staking-frontend/src/services/stakingService.ts
+++ b/pi-staking/pi-staking-frontend/src/services/stakingService.ts
@@ -207,6 +207,21 @@ class StakingService {
     }
   }
 
+  // Réinvestissement rapide: utilise claimable_balance et choisit un package éligible
+  async reinvestQuick(): Promise<{ success: boolean; message: string; data: any }> {
+    try {
+      const response = await api.post('/staking/reinvest-quick');
+      return response.data;
+    } catch (error: any) {
+      console.error('Erreur lors du réinvestissement rapide:', error);
+      return {
+        success: false,
+        data: null,
+        message: error.response?.data?.message || 'Impossible d\'effectuer le réinvestissement rapide',
+      };
+    }
+  }
+
   // ✅ Calculer les statistiques de staking pour l'utilisateur
   async getStakingStats(): Promise<{
     success: boolean;


### PR DESCRIPTION
## Amélioration UX: Claim groupé atomique + Réinvestissement rapide

Pourquoi
- Offrir une expérience fluide pour réclamer tous les gains en un clic, avec garanties d'idempotence.
- Permettre le réinvestissement immédiat des gains (claimable_balance) dans un package éligible, en respectant min/max et les règles de niveau.
- Clarifier la devise "Pi" et afficher les limites (min retrait, caps journaliers) côté interface.

Changements principaux
- Backend (Laravel)
  - POST /api/claims/bulk-claim: traitement atomique d'un lot d'investissements, idempotence par idempotency_key (Cache TTL 6h). Retour agrégé: total_claimed et détails par investment. Respect des locks existants via ClaimService.
  - POST /api/staking/reinvest-quick: réinvestit l'intégralité du claimable_balance dans un package régulier actif et éligible (min_amount), borné par max_amount. Messages d'erreur explicites si non éligible.
  - Routes API mises à jour.
  - Tests E2E: BulkClaimApiTest (succès, idempotence, non-éligible) et ReinvestQuickApiTest (absence de solde, succès).
- Frontend (/pi-staking-frontend)
  - Service claims: normalisation de /claims/available, mapping vers ClaimableInvestment, génération idempotency_key et envoi des investment_ids sur bulk-claim.
  - Service staking: ajout reinvestQuick().
  - Dashboard: 
    - Bouton "Réclamer Tout" avec état de progression (aria-busy) et récap du total en Pi.
    - CTA "Réinvestissement rapide" contextuel si claimable_balance >= min d'un package régulier.
    - Aide/tooltip: min retrait (2 Pi), caps/jour (Bronze 20, Silver 50, Gold 100, Diamond 200 Pi) et rappel des taux journaliers approximatifs.
    - Normalisation explicite de la devise "Pi" sur les montants ajoutés.

Impact
- L'utilisateur peut "Claim tout" de manière atomique et idempotente, avec feedback clair et montants en "Pi".
- Le réinvestissement rapide respecte les règles de staking (min/max, niveau) et réduit la friction.
- L'interface expose les caps de retrait par niveau et reste cohérente sur la devise.

Plan de test
- Backend: `php artisan test` — couvre bulk-claim (succès, idempotence, non-éligible) et reinvest-quick.
- Frontend: vérifier
  - Réclamations: bouton "Tout Réclamer" affiche le total, spinner pendant exécution, puis rafraîchit les données.
  - Réinvestissement rapide: bouton activé quand claimable >= min package, succès affiche confirmation et met à jour les soldes/investissements.
  - Accessibilité: aria-busy sur actions longues; labels présents.

Notes
- L'idempotence bulk-claim est mise en cache (TTL 6h). Peut être migrée en table dédiée si nécessaire.
- Le service ClaimService gère déjà l'idempotence journalière par investissement (firstOrCreate + lock), ce qui renforce la robustesse.


₍ᐢ•(ܫ)•ᐢ₎ Generated by [Capy](https://capy.ai) ([view task](https://capy.ai/project/5728a778-84af-11f0-a94e-3eef481a796b/task/72dea04c-b884-4808-984b-1e346bae632b))