### PR TITLE
Corriger l’erreur Builder::ordered() en ajoutant le scope ordered() sur StakingPackage

### DIFF
--- a/pi-staking/apps/backend/app/Models/StakingPackage.php
+++ b/pi-staking/apps/backend/app/Models/StakingPackage.php
@@ -65,6 +65,11 @@ class StakingPackage extends Model
         return $query->where('level', $level);
     }
 
+    public function scopeOrdered($query)
+    {
+        return $query->orderBy('sort_order')->orderBy('min_amount');
+    }
+
     public function canBeUsedBy(User $user): bool
     {
         if (!$this->is_active) {


### PR DESCRIPTION
## Objet
Corriger l’erreur "Call to undefined method Illuminate\Database\Eloquent\Builder::ordered()" en ajoutant un scope Eloquent `ordered()` au modèle `StakingPackage`.

## Changements
- Ajout de `scopeOrdered($query)` dans `App\Models\StakingPackage` qui applique un tri par défaut:
  - `sort_order` ascendant
  - puis `min_amount` ascendant
- Aucune modification dans `StakingService`: l’appel existant `StakingPackage::active()->ordered()->get()` (l. ~134) est conservé et fonctionne désormais.

## Pourquoi
- Le service de staking utilise `->ordered()` pour récupérer les packages actifs avec un ordre déterministe.
- Le scope n’existait pas, ce qui provoquait l’erreur `Builder::ordered()`.
- L’ajout du scope supprime l’erreur et garantit le tri par défaut désiré.

## Impact
- Correction ciblée (bug fix) sans effet de bord sur les autres scopes (`active`, `regular`, `discoveryBonus`, `forLevel`).
- Les packages actifs sont désormais renvoyés triés par `sort_order`, puis `min_amount`.

## Détails techniques
- Fichier modifié: `apps/backend/app/Models/StakingPackage.php`
  ```php
  public function scopeOrdered($query)
  {
      return $query->orderBy('sort_order')->orderBy('min_amount');
  }
  ```
- Commit: af02f94

## Vérification
- Compilation côté backend OK.
- L’endpoint/logique `getAvailablePackages()` n’émet plus d’erreur et renvoie une collection triée.

## Type de changement
- fix: correction d’une erreur d’appel de méthode manquante et ajout du tri par défaut.


₍ᐢ•(ܫ)•ᐢ₎ Generated by [Capy](https://capy.ai) ([view task](https://capy.ai/project/573006dd-84af-11f0-a94e-3eef481a796b/task/fc0cd02d-7024-4b31-bfbf-339e63f90c03))