### PR TITLE
Implement referral linking on registration + URL prefill; add users.referred_by (FK nullOnDelete)

### DIFF
--- a/pi-staking/apps/backend/app/Http/Controllers/AuthController.php
+++ b/pi-staking/apps/backend/app/Http/Controllers/AuthController.php
@@ -14,6 +14,7 @@ use Illuminate\Support\Facades\Password;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\URL;
 use App\Services\NotificationService;
+use App\Services\ReferralService;
 
 class AuthController extends Controller
 {
@@ -230,11 +231,27 @@ class AuthController extends Controller
 
         $data = $validator->validated();
 
+        $referrer = null;
+        if (!empty($data['referral_code'] ?? null)) {
+            $referrer = app(ReferralService::class)->validateReferralCode($data['referral_code']);
+            if (!$referrer) {
+                return response()->json([
+                    'success' => false,
+                    'message' => 'Code de parrainage invalide',
+                    'errors' => [
+                        'referral_code' => ['Code de parrainage invalide']
+                    ]
+                ], 422);
+            }
+        }
+
         $user = User::create([
             'username' => $data['username'],
             'email' => $data['email'],
             'password' => Hash::make($data['password']),
             'current_level' => 'bronze',
+            'referred_by' => $referrer?->id,
+            'referral_code' => app(ReferralService::class)->generateUniqueReferralCode(),
         ]);
 
         if (method_exists($user, 'assignRole')) {

--- a/pi-staking/apps/backend/database/migrations/2025_09_20_120000_add_referred_by_to_users_table.php
+++ b/pi-staking/apps/backend/database/migrations/2025_09_20_120000_add_referred_by_to_users_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            if (!Schema::hasColumn('users', 'referred_by')) {
+                $table->unsignedBigInteger('referred_by')->nullable()->index()->after('referral_code');
+                $table->foreign('referred_by')
+                    ->references('id')->on('users')
+                    ->nullOnDelete();
+            }
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            if (Schema::hasColumn('users', 'referred_by')) {
+                $table->dropForeign(['referred_by']);
+                $table->dropColumn('referred_by');
+            }
+        });
+    }
+};

--- a/pi-staking/pi-staking-frontend/src/components/AuthPage.tsx
+++ b/pi-staking/pi-staking-frontend/src/components/AuthPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -37,6 +37,14 @@ export function AuthPage({ onBack }: AuthPageProps) {
   });
   
   const [activeTab, setActiveTab] = useState('login');
+
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const ref = params.get('ref');
+    if (ref && !registerForm.referral_code) {
+      setRegisterForm(prev => ({ ...prev, referral_code: ref }));
+    }
+  }, [activeTab, registerForm.referral_code]);
 
   const handleBack = () => {
     if (onBack) {


### PR DESCRIPTION
# Implement referral linking on registration + URL prefill; add users.referred_by (FK nullOnDelete)

## Why
- Convert referral traffic at signup by validating and linking referred_by when a code is provided.
- Ensure every new user receives a unique referral_code for future sharing.
- Reduce friction on the frontend by pre-filling the referral code from ?ref=.

## What changed

### Backend (Laravel)
- AuthController::register
  - Keep validation: `referral_code` nullable|string|max:255
  - If `referral_code` present: validate via `ReferralService::validateReferralCode()`
    - If invalid: respond 422 with
      ```json
      {
        "success": false,
        "message": "Code de parrainage invalide",
        "errors": { "referral_code": ["Code de parrainage invalide"] }
      }
      ```
  - On user creation: set
    - `referred_by` => referrer id (if found)
    - `referral_code` => `ReferralService::generateUniqueReferralCode()`
  - No email notification to referrer. Keep existing Sanctum token, welcome bonus grant, and email verification logic unchanged.

- Migration: `2025_09_20_120000_add_referred_by_to_users_table.php`
  - Add `users.referred_by` (unsignedBigInteger, nullable, indexed)
  - FK → `users.id` with `nullOnDelete()`

### Frontend (React)
- AuthPage.tsx
  - On mount / tab change, read `window.location.search` and if `ref` exists, prefill `registerForm.referral_code`.
  - No other UI change; POST payload already includes `referral_code`.

## API responses
- Success (201):
  ```json
  {
    "success": true,
    "message": "Inscription réussie.",
    "data": { "user": {…}, "token": "…", "bonus_grant": {…} }
  }
  ```
- Error (422 invalid code):
  ```json
  {
    "success": false,
    "message": "Code de parrainage invalide",
    "errors": { "referral_code": ["Code de parrainage invalide"] }
  }
  ```

## Data/DB
- New users without a referral code → `referred_by = NULL`; a unique `referral_code` is generated.
- New users with a valid code → `referred_by = referrer.id`; a unique `referral_code` is generated.
- `users.referred_by` exists, nullable, indexed, FK nullOnDelete.

## Deployment
- Run database migrations in backend: `php artisan migrate`
- No env changes. No emails or bonuses altered at signup beyond existing logic.

## Test plan (high-level)
- Backend
  - POST /api/auth/register without `referral_code` → 201, user has `referred_by = null`, `referral_code` set.
  - POST with `referral_code` invalid → 422 as above.
  - POST with valid `referral_code` → 201, `referred_by = referrer.id`.
- Frontend
  - Navigate to `/register?ref=PI-ABC123` → field "Code de parrainage" auto-filled.
  - Invalid code shows error from `response.data.message` (fall back still handled).

## Notes
- Commissions remain handled later via `ReferralService::activateReferral` on first qualifying investment.
- No referrer notification at signup.


₍ᐢ•(ܫ)•ᐢ₎ Generated by [Capy](https://capy.ai) ([view task](https://capy.ai/project/57302e72-84af-11f0-a94e-3eef481a796b/task/59b8a6e7-fcb6-42b9-8f98-f475427f9e17))