### PR TITLE
Align registration flow: require first/last name; optional referral_code; dev CORS for Bearer

### DIFF
--- a/pi-staking/apps/backend/.env.example
+++ b/pi-staking/apps/backend/.env.example
@@ -4,6 +4,7 @@ APP_KEY=
 APP_DEBUG=true
 APP_URL=http://localhost:8000
 FRONTEND_URL=http://localhost:5173
+# FRONTEND_URLS=http://localhost:5173,http://127.0.0.1:5173
 
 MAIL_MAILER=smtp
 MAIL_HOST=sandbox.smtp.mailtrap.io

--- a/pi-staking/apps/backend/app/Http/Controllers/AuthController.php
+++ b/pi-staking/apps/backend/app/Http/Controllers/AuthController.php
@@ -215,6 +215,8 @@ class AuthController extends Controller
     public function register(Request $request, NotificationService $notifications): JsonResponse
     {
         $validator = Validator::make($request->all(), [
+            'first_name' => 'required|string|max:255',
+            'last_name' => 'required|string|max:255',
             'username' => 'required|string|max:255|unique:users,username',
             'email' => 'required|email|unique:users,email',
             'password' => 'required|min:8|confirmed',
@@ -246,6 +248,8 @@ class AuthController extends Controller
         }
 
         $user = User::create([
+            'first_name' => $data['first_name'],
+            'last_name' => $data['last_name'],
             'username' => $data['username'],
             'email' => $data['email'],
             'password' => Hash::make($data['password']),

--- a/pi-staking/apps/backend/app/Http/Controllers/AuthController.php
+++ b/pi-staking/apps/backend/app/Http/Controllers/AuthController.php
@@ -118,8 +118,10 @@ class AuthController extends Controller
         $user = Auth::user();
 
         $validator = Validator::make($request->all(), [
-            'name'  => 'nullable|string|max:255',
+            'first_name' => 'nullable|string|max:255',
+            'last_name' => 'nullable|string|max:255',
             'email' => 'nullable|email|unique:users,email,' . $user->id,
+            'username' => 'nullable|string|max:255|unique:users,username,' . $user->id,
         ]);
 
         if ($validator->fails()) {

--- a/pi-staking/apps/backend/app/Models/User.php
+++ b/pi-staking/apps/backend/app/Models/User.php
@@ -19,6 +19,8 @@ class User extends Authenticatable implements MustVerifyEmail
      * The attributes that are mass assignable.
      */
     protected $fillable = [
+        'first_name',
+        'last_name',
         'username',
         'email',
         'password',

--- a/pi-staking/apps/backend/config/app.php
+++ b/pi-staking/apps/backend/config/app.php
@@ -15,6 +15,8 @@ return [
 
     'name' => env('APP_NAME', 'Laravel'),
 
+    'frontend_url' => env('FRONTEND_URL', 'http://localhost:5173'),
+
     /*
     |--------------------------------------------------------------------------
     | Application Environment

--- a/pi-staking/apps/backend/config/cors.php
+++ b/pi-staking/apps/backend/config/cors.php
@@ -19,7 +19,7 @@ return [
 
     'allowed_methods' => ['*'],
 
-    'allowed_origins' => ['http://localhost:5173'],
+    'allowed_origins' => array_filter(array_map('trim', explode(',', env('FRONTEND_URLS', env('FRONTEND_URL', 'http://localhost:5173,http://127.0.0.1:5173'))))),
 
     'allowed_origins_patterns' => [],
 
@@ -29,6 +29,6 @@ return [
 
     'max_age' => 0,
 
-    'supports_credentials' => true,
+    'supports_credentials' => false,
 
 ];

--- a/pi-staking/packages/shared-types/src/user.ts
+++ b/pi-staking/packages/shared-types/src/user.ts
@@ -20,6 +20,8 @@ export interface User {
   id: number;
   username: string;
   email: string;
+  first_name?: string;
+  last_name?: string;
   email_verified_at: string | null;
   
   // Authentication & Authorization

--- a/pi-staking/pi-staking-frontend/src/components/AuthPage.tsx
+++ b/pi-staking/pi-staking-frontend/src/components/AuthPage.tsx
@@ -23,6 +23,8 @@ export function AuthPage({ onBack }: AuthPageProps) {
   });
   
   const [registerForm, setRegisterForm] = useState({
+    first_name: '',
+    last_name: '',
     username: '',
     email: '',
     password: '',
@@ -196,6 +198,28 @@ export function AuthPage({ onBack }: AuthPageProps) {
                   </CardDescription>
                 </CardHeader>
                 <CardContent className="space-y-4">
+                  <div className="space-y-2">
+                    <Label htmlFor="first_name">Prénom</Label>
+                    <Input
+                      id="first_name"
+                      type="text"
+                      placeholder="Votre prénom"
+                      value={registerForm.first_name}
+                      onChange={(e) => setRegisterForm(prev => ({ ...prev, first_name: e.target.value }))}
+                      required
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="last_name">Nom</Label>
+                    <Input
+                      id="last_name"
+                      type="text"
+                      placeholder="Votre nom"
+                      value={registerForm.last_name}
+                      onChange={(e) => setRegisterForm(prev => ({ ...prev, last_name: e.target.value }))}
+                      required
+                    />
+                  </div>
                   <div className="space-y-2">
                     <Label htmlFor="username">Nom d'utilisateur</Label>
                     <Input

--- a/pi-staking/pi-staking-frontend/src/lib/api-enhanced.ts
+++ b/pi-staking/pi-staking-frontend/src/lib/api-enhanced.ts
@@ -8,7 +8,7 @@ const SANCTUM_BASE_URL = config.api.baseUrl;
 // Instance Axios principale
 export const apiClient = axios.create({
   baseURL: API_BASE_URL,
-  withCredentials: true,
+  withCredentials: false,
   headers: {
     'Content-Type': 'application/json',
     'Accept': 'application/json',
@@ -19,7 +19,7 @@ export const apiClient = axios.create({
 // Instance pour Sanctum CSRF
 export const sanctumClient = axios.create({
   baseURL: SANCTUM_BASE_URL,
-  withCredentials: true
+  withCredentials: false
 });
 
 // Intercepteur pour gestion automatique des tokens

--- a/pi-staking/pi-staking-frontend/src/services/authService.ts
+++ b/pi-staking/pi-staking-frontend/src/services/authService.ts
@@ -7,6 +7,8 @@ export interface LoginCredentials {
 }
 
 export interface RegisterData {
+  first_name: string;
+  last_name: string;
   username: string;
   email: string;
   password: string;
@@ -15,6 +17,8 @@ export interface RegisterData {
 }
 
 export interface RegisterCredentials {
+  first_name: string;
+  last_name: string;
   username: string;
   email: string;
   password: string;


### PR DESCRIPTION
# Align registration flow and dev CORS for Bearer tokens

## Why
- Keep backend and frontend in sync for user signup while respecting DB schema (users.first_name, users.last_name are non-nullable).
- Make referral_code optional across the stack.
- Simplify CORS for development when using Authorization: Bearer (no cookies), to avoid unnecessary preflight friction.

## What changed

### Backend (Laravel)
- AuthController::register()
  - Validation now requires: `first_name`, `last_name`, `username`, `email`, `password` (confirmed)
  - `referral_code` remains optional; if present it is validated; `referred_by` set accordingly
  - User creation now persists `first_name` and `last_name`
- AuthController::updateProfile()
  - Accepts `first_name`, `last_name`, `email`, `username` with proper uniqueness
- App\Models\User
  - Added `first_name`, `last_name` to `$fillable`
- config/cors.php
  - `allowed_origins` now read from `FRONTEND_URLS` (comma-separated) or `FRONTEND_URL` with sensible defaults including `http://localhost:5173` and `http://127.0.0.1:5173`
  - `supports_credentials` set to `false` (we use Bearer tokens, not cookies)
  - `allowed_headers` and `allowed_methods` remain `['*']`
- config/app.php
  - Exposes `frontend_url` via `env('FRONTEND_URL', 'http://localhost:5173')` for internal URL generation
- apps/backend/.env.example
  - Keeps `FRONTEND_URL=http://localhost:5173`
  - Adds commented example `# FRONTEND_URLS=http://localhost:5173,http://127.0.0.1:5173`

### Frontend (React/Vite/TS)
- src/components/AuthPage.tsx
  - Adds required inputs for `first_name` and `last_name`
  - Keeps local password confirmation logic
- src/services/authService.ts
  - Extends `RegisterData`/`RegisterCredentials` to include `first_name`, `last_name`
  - Sends payload with exact backend keys
- src/lib/api-enhanced.ts
  - Sets Axios `withCredentials=false` (Bearer-only)
  - Interceptor still sets `Authorization: Bearer <token>` when present

### Shared types
- packages/shared-types/src/user.ts
  - Adds `first_name?: string` and `last_name?: string` (optional to avoid breaking existing imports)

## Impact
- Registration requires two additional fields (first_name, last_name). Existing login/refresh/me flows unaffected.
- Development CORS works out-of-the-box with Bearer tokens (no cookies). If any consumer relied on cookies/CSRF in dev, they should switch to Bearer (already the case in this repo).

## How to test (dev)
1) Register
```
curl -i -X POST http://localhost:8000/api/auth/register \
  -H 'Content-Type: application/json' \
  -d '{
    "first_name": "Ada",
    "last_name": "Lovelace",
    "username": "adal",
    "email": "ada@example.com",
    "password": "password123",
    "password_confirmation": "password123"
  }'
```
Expect 201 with `{ success: true, data: { user, token, ... } }`.

2) Me with Bearer
```
TOKEN=... # copy from previous response
curl -i http://localhost:8000/api/auth/me -H "Authorization: Bearer $TOKEN"
```
Expect 200 with user including `first_name` and `last_name`.

## Configuration notes
- In dev, set `FRONTEND_URL=http://localhost:5173` (and optionally `FRONTEND_URLS` to include `http://127.0.0.1:5173`).
- You can keep using the Vite proxy (`/api` → `http://localhost:8000`) to avoid CORS entirely.

## Acceptance
- POST /api/auth/register with names returns success + token
- Frontend blocks submission if first/last name are empty
- CORS allows configured origin and Authorization header in dev
- No regressions observed on login and protected endpoints

₍ᐢ•(ܫ)•ᐢ₎ Generated by [Capy](https://capy.ai) ([view task](https://capy.ai/project/57302e72-84af-11f0-a94e-3eef481a796b/task/e671ea2c-599d-4213-ab37-4e4e8408dbaf))