### PR TITLE
Production setup: single-domain Nginx + PHP-FPM, envs, Axios alignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,98 @@
+# Pi Staking — Production
+
+This repository ships a ready-to-clone production layout (no Docker) to serve the Vite/React frontend and expose the Laravel backend on the same domain using Nginx + PHP-FPM.
+
+- Frontend (Vite/React): `pi-staking/pi-staking-frontend`
+- Backend (Laravel): `pi-staking/apps/backend`
+
+Both are served from the same public domain: `https://pi-staking.com`
+- Frontend: root of the domain
+- Backend API: available under both `/backend/api/*` (preferred) and `/api/*` (compat)
+
+## 1) Environment files (production)
+Do not commit secrets in documentation. Fill these variables in your deployment environment files.
+
+### Backend: `pi-staking/apps/backend/.env.production`
+Required keys (non-exhaustive):
+- APP_NAME
+- APP_ENV
+- APP_DEBUG
+- APP_URL
+- FRONTEND_URL
+- SANCTUM_STATEFUL_DOMAINS
+- DB_CONNECTION, DB_HOST, DB_PORT, DB_DATABASE, DB_USERNAME, DB_PASSWORD
+- SESSION_DRIVER, SESSION_LIFETIME, SESSION_SECURE_COOKIE
+- LOG_CHANNEL, LOG_LEVEL
+
+Notes:
+- APP_KEY is not included; generate it on the server (see commands below).
+- CORS relies on `FRONTEND_URL` or `FRONTEND_URLS` (see `apps/backend/config/cors.php`).
+
+### Frontend: `pi-staking/pi-staking-frontend/.env.production`
+Important production keys:
+- VITE_API_BASE_URL (e.g. `https://pi-staking.com`)
+- VITE_API_PREFIX (e.g. `/backend/api`)
+- VITE_APP_NAME
+- VITE_APP_ENVIRONMENT (set to `production`)
+- VITE_ENABLE_DEV_TOOLS=false
+- VITE_ENABLE_DEBUG_LOGS=false
+
+All other existing variables should be kept as-is unless you need to change them.
+
+## 2) Nginx + PHP-FPM
+An example configuration is provided at:
+
+- `docs/nginx/pi-staking.conf`
+
+Key points:
+- Root points to the built frontend: `/var/www/pi-staking/pi-staking-frontend/dist`
+- SPA fallback via `try_files $uri /index.html`
+- Two API locations for compatibility:
+  - `/backend/api/*` rewritten to `/api/*` for Laravel
+  - `/api/*` directly handled by Laravel
+- PHP executed only via the backend entrypoint; direct `*.php` requests are blocked
+- Basic security headers are included as an example
+- HTTP→HTTPS redirect and ACME challenge locations are provided as commented examples
+
+## 3) Expected server layout
+```
+/var/www/pi-staking/
+  ├─ pi-staking-frontend/            # Frontend project (build to ./dist)
+  │   └─ dist/                       # Built assets served by Nginx
+  └─ apps/
+      └─ backend/                    # Laravel backend
+          └─ public/index.php        # Entry point used by Nginx
+```
+
+## 4) Laravel production commands (run on the server)
+From `pi-staking/apps/backend`:
+
+```
+php artisan key:generate
+php artisan migrate --force
+php artisan storage:link
+php artisan config:cache
+php artisan route:cache
+php artisan view:cache
+php artisan optimize
+```
+
+Ensure correct permissions for `storage/` and `bootstrap/cache/` and that PHP-FPM (8.2) has access.
+
+## 5) Post-deployment checklist
+- [ ] `https://pi-staking.com/backend/api/health` returns `{ "status": "OK" }`
+- [ ] API also responds at `https://pi-staking.com/api/*` (compat)
+- [ ] CORS works from `https://pi-staking.com` (fetch/axios OK)
+- [ ] Authentication, staking packages, transactions endpoints respond (200/401 as expected)
+- [ ] `APP_DEBUG=false` is in effect
+
+## 6) How the API path translation works
+- Laravel routes stay under `/api` (see `apps/backend/routes/api.php`).
+- Nginx rewrites `/backend/api/...` → `/api/...` before passing the request to Laravel.
+- No changes to business logic or route prefixes are required in code.
+
+## 7) Frontend configuration integration
+- The frontend reads its API settings from `src/lib/config.ts`.
+- With `VITE_API_BASE_URL=https://pi-staking.com` and `VITE_API_PREFIX=/backend/api`, the Axios baseURL becomes `https://pi-staking.com/backend/api`.
+
+If you need to adjust anything specific to your hosting, duplicate the provided Nginx example and tune it accordingly.

--- a/docs/nginx/pi-staking.conf
+++ b/docs/nginx/pi-staking.conf
@@ -72,6 +72,15 @@ server {
     fastcgi_pass unix:/run/php/php8.2-fpm.sock;
   }
 
+  # Sanctum endpoints (optional; enables /sanctum/csrf-cookie if used)
+  location ^~ /sanctum/ {
+    include fastcgi_params;
+    fastcgi_param SCRIPT_FILENAME /var/www/pi-staking/apps/backend/public/index.php;
+    fastcgi_param PATH_INFO "";
+    fastcgi_param QUERY_STRING $query_string;
+    fastcgi_pass unix:/run/php/php8.2-fpm.sock;
+  }
+
   # Block direct PHP execution anywhere else
   location ~ \.php$ {
     return 404;

--- a/docs/nginx/pi-staking.conf
+++ b/docs/nginx/pi-staking.conf
@@ -1,0 +1,84 @@
+# Pi Staking — Nginx example configuration (single domain)
+# Serves React/Vite frontend and proxies Laravel backend via PHP-FPM
+# Domain: pi-staking.com
+# Frontend build path: /var/www/pi-staking/pi-staking-frontend/dist
+# Backend public index:   /var/www/pi-staking/apps/backend/public/index.php
+# PHP-FPM socket:         unix:/run/php/php8.2-fpm.sock
+
+# --- Optional HTTP->HTTPS redirect (uncomment when SSL is configured) ---
+# server {
+#   listen 80;
+#   server_name pi-staking.com;
+#   # ACME challenge for Certbot/Lego
+#   # location ^~ /.well-known/acme-challenge/ {
+#   #   root /var/www/pi-staking/.acme-challenge;
+#   #   default_type "text/plain";
+#   #   try_files $uri =404;
+#   # }
+#   return 301 https://$host$request_uri;
+# }
+
+server {
+  listen 80;
+  # If using HTTPS directly, replace with:
+  # listen 443 ssl http2;
+  server_name pi-staking.com;
+
+  # SSL example (uncomment and set paths when ready)
+  # ssl_certificate     /etc/letsencrypt/live/pi-staking.com/fullchain.pem;
+  # ssl_certificate_key /etc/letsencrypt/live/pi-staking.com/privkey.pem;
+  # include /etc/letsencrypt/options-ssl-nginx.conf;
+  # ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
+
+  # Frontend build
+  root /var/www/pi-staking/pi-staking-frontend/dist;
+  index index.html;
+
+  # Basic security headers (adjust to your policy)
+  add_header X-Frame-Options "SAMEORIGIN" always;
+  add_header X-Content-Type-Options "nosniff" always;
+  add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+  add_header Permissions-Policy "geolocation=(), microphone=(), camera=()" always;
+
+  # Static assets caching (optional)
+  location ~* \.(?:css|js|jpg|jpeg|gif|png|svg|ico|webp)$ {
+    expires 7d;
+    access_log off;
+    add_header Cache-Control "public, max-age=604800, immutable";
+    try_files $uri =404;
+  }
+
+  # SPA fallback
+  location / {
+    try_files $uri $uri/ /index.html;
+  }
+
+  # API compatibility layer 1: preferred — /backend/api -> /api (Laravel)
+  location ~ ^/backend/api(/.*)?$ {
+    rewrite ^/backend/api/(.*)$ /api/$1 break;
+    include fastcgi_params;
+    fastcgi_param SCRIPT_FILENAME /var/www/pi-staking/apps/backend/public/index.php;
+    fastcgi_param PATH_INFO "";
+    fastcgi_param QUERY_STRING $query_string;
+    fastcgi_pass unix:/run/php/php8.2-fpm.sock;
+  }
+
+  # API compatibility layer 2: legacy direct /api (no rewrite)
+  location ~ ^/api(/.*)?$ {
+    include fastcgi_params;
+    fastcgi_param SCRIPT_FILENAME /var/www/pi-staking/apps/backend/public/index.php;
+    fastcgi_param PATH_INFO "";
+    fastcgi_param QUERY_STRING $query_string;
+    fastcgi_pass unix:/run/php/php8.2-fpm.sock;
+  }
+
+  # Block direct PHP execution anywhere else
+  location ~ \.php$ {
+    return 404;
+  }
+
+  # Optional gzip (safe defaults)
+  gzip on;
+  gzip_types text/plain text/css application/json application/javascript application/xml+rss application/xml image/svg+xml;
+  gzip_min_length 256;
+}

--- a/pi-staking/apps/backend/.env.production
+++ b/pi-staking/apps/backend/.env.production
@@ -1,0 +1,25 @@
+APP_NAME="Pi Staking"
+APP_ENV=production
+APP_DEBUG=false
+APP_URL=https://pi-staking.com
+
+# Frontend URL for CORS
+FRONTEND_URL=https://pi-staking.com
+SANCTUM_STATEFUL_DOMAINS=pi-staking.com
+
+# Database (local MySQL)
+DB_CONNECTION=mysql
+DB_HOST=localhost
+DB_PORT=3306
+DB_DATABASE=u110701636_pistaking
+DB_USERNAME=u110701636_pistaking
+DB_PASSWORD="J1@eY?nmlw"
+
+# Sessions / Cookies
+SESSION_DRIVER=file
+SESSION_LIFETIME=120
+SESSION_SECURE_COOKIE=true
+
+# Logs
+LOG_CHANNEL=stack
+LOG_LEVEL=info

--- a/pi-staking/apps/backend/.gitignore
+++ b/pi-staking/apps/backend/.gitignore
@@ -8,7 +8,7 @@
 /vendor
 .env
 .env.backup
-.env.production
+#.env.production is tracked for production template
 .phpactor.json
 .phpunit.result.cache
 Homestead.json

--- a/pi-staking/pi-staking-frontend/.env.production
+++ b/pi-staking/pi-staking-frontend/.env.production
@@ -2,8 +2,8 @@
 # Ce fichier contient la configuration pour l'environnement de production
 
 # API Backend Configuration
-VITE_API_BASE_URL=https://api.pistaking.com
-VITE_API_PREFIX=/api
+VITE_API_BASE_URL=https://pi-staking.com
+VITE_API_PREFIX=/backend/api
 
 # Application Configuration
 VITE_APP_NAME="Pi Staking Platform"

--- a/pi-staking/pi-staking-frontend/src/lib/api.ts
+++ b/pi-staking/pi-staking-frontend/src/lib/api.ts
@@ -5,13 +5,13 @@ export const API_BASE_URL = (config.api.baseUrl || import.meta.env.VITE_API_BASE
 
 const apiClient = axios.create({
   baseURL: API_BASE_URL,
-  withCredentials: true,
+  withCredentials: false,
   headers: {
     'Content-Type': 'application/json',
     'Accept': 'application/json',
     'X-Requested-With': 'XMLHttpRequest'
   },
-  timeout: 10000
+  timeout: config.api.timeout
 });
 
 apiClient.interceptors.request.use((cfg) => {


### PR DESCRIPTION
## Summary
Prepare production deployment for a single-domain setup (https://pi-staking.com) serving the Vite/React frontend at the root and the Laravel backend API under both /backend/api/* (preferred) and /api/* (compat), using Nginx + PHP-FPM and local MySQL.

## Why
- Enable cloning-based deployment without Docker.
- Serve frontend and backend on the same domain to avoid cross-origin complexity.
- Preserve Laravel route prefix (/api) while exposing /backend/api via Nginx rewrite.
- Align frontend Axios configuration with production paths and authentication strategy.

## Changes
- docs/nginx/pi-staking.conf (new): example Nginx vhost
  - root → /var/www/pi-staking/pi-staking-frontend/dist
  - location ~ ^/backend/api(/.*)?$ → rewrite to /api/$1 and pass to PHP-FPM
  - location ~ ^/api(/.*)?$ → pass to PHP-FPM (compat)
  - location ^~ /sanctum/ → pass to PHP-FPM (optional CSRF cookie endpoint)
  - SPA fallback try_files, basic security headers, optional HTTP→HTTPS and ACME examples
  - block direct *.php execution outside the backend entrypoint
- pi-staking/apps/backend/.env.production (new): production env template per spec (includes DB config as provided);
  - FRONTEND_URL=https://pi-staking.com for CORS
  - APP_DEBUG=false, SESSION_SECURE_COOKIE=true, LOG_LEVEL=info
- pi-staking/pi-staking-frontend/.env.production (updated):
  - VITE_API_BASE_URL=https://pi-staking.com
  - VITE_API_PREFIX=/backend/api
  - Leave other keys as-is
- pi-staking-frontend/src/lib/api.ts (updated):
  - withCredentials: false (we use Bearer tokens, not cookie-based Sanctum)
  - timeout now reads from config.api.timeout
- Root README.md (new): "Production" section covering envs, Nginx file path/role, Laravel prod commands, expected server paths, and a post-deploy checklist.
- pi-staking/apps/backend/.gitignore (updated): allow tracking of .env.production template.

## Configuration/Behaviour notes
- Backend CORS (apps/backend/config/cors.php) already reads FRONTEND_URL(S); no hardcoding added; supports_credentials remains false.
- Axios baseURL in production resolves to https://pi-staking.com/backend/api.
- Laravel routes remain under /api; Nginx translates /backend/api → /api.
- Added /sanctum/ pass-through so optional CSRF init endpoint doesn’t 404, even though auth relies on Bearer tokens.

## Impact
- Production deployment is simplified on a single domain; avoids CORS headaches.
- Dev builds are unaffected; only one minor change to src/lib/api.ts (withCredentials=false) which aligns with the current Bearer-token flow.

## Post-deploy checklist
- https://pi-staking.com/backend/api/health returns {"status":"OK"}
- API responds on both /backend/api/* and /api/*
- CORS requests from https://pi-staking.com succeed
- Auth, staking packages, and transactions endpoints behave as expected (200/401)
- APP_DEBUG=false in production

## Security/Secrets
- The backend .env.production is included as requested in the spec for a cloning-based deployment. If preferred, we can switch to an .env.production.example and inject secrets server-side; happy to follow your preference in a follow-up.

## Testing
- Build frontend for production, deploy Nginx conf, and point domain to the server.
- Verify health endpoint and run a login→me→logout flow using Authorization: Bearer <token>.



₍ᐢ•(ܫ)•ᐢ₎ Generated by [Capy](https://capy.ai) ([view task](https://capy.ai/project/57259b60-84af-11f0-a94e-3eef481a796b/task/0e8764a6-2b04-4a05-8c22-2a52eccf576d))